### PR TITLE
Feature: 풀필먼트 조회 모델 & 페이징 쿼리 구현

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -6,7 +6,17 @@
       <profile name="Gradle Imported" enabled="true">
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/querydsl-apt/5.1.0/3b1cbe05851840b5dc926833908747a193c097cc/querydsl-apt-5.1.0-jakarta.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/jakarta.annotation/jakarta.annotation-api/2.1.1/48b9bda22b091b1f48b13af03fe36db3be6e1ae3/jakarta.annotation-api-2.1.1.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/jakarta.persistence/jakarta.persistence-api/3.1.0/66901fa1c373c6aff65c13791cc11da72060a8d6/jakarta.persistence-api-3.1.0.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.38/57f8f5e02e92a30fd21b80cbd426a4172b5f8e29/lombok-1.18.38.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/querydsl-codegen/5.1.0/a8504ea51fbc2258543cedab6a37fe6039b2d20a/querydsl-codegen-5.1.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/querydsl-core/5.1.0/be322c3fe98de8e7c204afb8860bfabd81a3bafd/querydsl-core-5.1.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/codegen-utils/5.1.0/ba401554d613760617992eafb6cdba175c811e6f/codegen-utils-5.1.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/javax.inject/javax.inject/1/6975da39a7040257bd51d21a231b76c915872d38/javax.inject-1.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/io.github.classgraph/classgraph/4.8.146/360448a09bfa5689d89cfa97fea53b3fdefa9c23/classgraph-4.8.146.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.mysema.commons/mysema-commons-lang/0.2.4/d09c8489d54251a6c22fbce804bdd4a070557317/mysema-commons-lang-0.2.4.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.eclipse.jdt/ecj/3.26.0/4837be609a3368a0f7e7cf0dc1bdbc7fe94993de/ecj-3.26.0.jar" />
         </processorPath>
         <module name="manibogo-oms-v2.main" />
       </profile>

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="manibogo_oms_v2@localhost" uuid="8ef8c328-3bd3-493d-9f08-533f41e8c0ac">
+      <driver-ref>mariadb</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.mariadb.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mariadb://localhost:3306/manibogo_oms_v2</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="JavaScriptLibraryMappings">
-    <file url="file://$PROJECT_DIR$/build/generated/sources/annotationProcessor/java/main" libraries="{babel-polyfill, bootstrap, bootstrap-icons, officecrypto-tool, xlsx.full}" />
     <file url="file://$PROJECT_DIR$/src/main" libraries="{babel-polyfill, bootstrap, bootstrap-icons, officecrypto-tool, xlsx.full}" />
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/manibogo-oms-v2.main.iml" filepath="$PROJECT_DIR$/.idea/modules/manibogo-oms-v2.main.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/modules/manibogo-oms-v2.main.iml
+++ b/.idea/modules/manibogo-oms-v2.main.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main">
-      <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
-    </content>
-  </component>
-</module>

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	implementation 'com.querydsl:querydsl-apt:5.0.0'
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	implementation 'com.querydsl:querydsl-core:5.0.0'
+
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
@@ -39,4 +49,22 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// Querydsl 빌드 옵션 설정
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(generated)
 }

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/common/model/QAddress.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/common/model/QAddress.java
@@ -1,0 +1,41 @@
+package kr.tatine.manibogo_oms_v2.common.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QAddress is a Querydsl query type for Address
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QAddress extends BeanPath<Address> {
+
+    private static final long serialVersionUID = -1001637241L;
+
+    public static final QAddress address = new QAddress("address");
+
+    public final StringPath address1 = createString("address1");
+
+    public final StringPath address2 = createString("address2");
+
+    public final StringPath zipCode = createString("zipCode");
+
+    public QAddress(String variable) {
+        super(Address.class, forVariable(variable));
+    }
+
+    public QAddress(Path<? extends Address> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QAddress(PathMetadata metadata) {
+        super(Address.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/common/model/QMoney.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/common/model/QMoney.java
@@ -1,0 +1,37 @@
+package kr.tatine.manibogo_oms_v2.common.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QMoney is a Querydsl query type for Money
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QMoney extends BeanPath<Money> {
+
+    private static final long serialVersionUID = -1567274989L;
+
+    public static final QMoney money = new QMoney("money");
+
+    public final NumberPath<Long> value = createNumber("value", Long.class);
+
+    public QMoney(String variable) {
+        super(Money.class, forVariable(variable));
+    }
+
+    public QMoney(Path<? extends Money> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMoney(PathMetadata metadata) {
+        super(Money.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/common/model/QPhoneNumber.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/common/model/QPhoneNumber.java
@@ -1,0 +1,37 @@
+package kr.tatine.manibogo_oms_v2.common.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QPhoneNumber is a Querydsl query type for PhoneNumber
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QPhoneNumber extends BeanPath<PhoneNumber> {
+
+    private static final long serialVersionUID = 36820842L;
+
+    public static final QPhoneNumber phoneNumber1 = new QPhoneNumber("phoneNumber1");
+
+    public final StringPath phoneNumber = createString("phoneNumber");
+
+    public QPhoneNumber(String variable) {
+        super(PhoneNumber.class, forVariable(variable));
+    }
+
+    public QPhoneNumber(Path<? extends PhoneNumber> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QPhoneNumber(PathMetadata metadata) {
+        super(PhoneNumber.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/option/QOption.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/option/QOption.java
@@ -1,0 +1,54 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.command.domain.option;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QOption is a Querydsl query type for Option
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QOption extends EntityPathBase<Option> {
+
+    private static final long serialVersionUID = 387454226L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QOption option = new QOption("option");
+
+    public final QOptionId id;
+
+    public final StringPath label = createString("label");
+
+    public final kr.tatine.manibogo_oms_v2.fulfillment.command.domain.product.QProductNumber productNumber;
+
+    public QOption(String variable) {
+        this(Option.class, forVariable(variable), INITS);
+    }
+
+    public QOption(Path<? extends Option> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QOption(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QOption(PathMetadata metadata, PathInits inits) {
+        this(Option.class, metadata, inits);
+    }
+
+    public QOption(Class<? extends Option> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.id = inits.isInitialized("id") ? new QOptionId(forProperty("id")) : null;
+        this.productNumber = inits.isInitialized("productNumber") ? new kr.tatine.manibogo_oms_v2.fulfillment.command.domain.product.QProductNumber(forProperty("productNumber")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/option/QOptionId.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/option/QOptionId.java
@@ -1,0 +1,39 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.command.domain.option;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QOptionId is a Querydsl query type for OptionId
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QOptionId extends BeanPath<OptionId> {
+
+    private static final long serialVersionUID = -1318641203L;
+
+    public static final QOptionId optionId = new QOptionId("optionId");
+
+    public final StringPath key = createString("key");
+
+    public final StringPath value = createString("value");
+
+    public QOptionId(String variable) {
+        super(OptionId.class, forVariable(variable));
+    }
+
+    public QOptionId(Path<? extends OptionId> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QOptionId(PathMetadata metadata) {
+        super(OptionId.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/QItemOrder.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/QItemOrder.java
@@ -1,0 +1,74 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QItemOrder is a Querydsl query type for ItemOrder
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QItemOrder extends EntityPathBase<ItemOrder> {
+
+    private static final long serialVersionUID = -1449441894L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QItemOrder itemOrder = new QItemOrder("itemOrder");
+
+    public final NumberPath<Integer> amount = createNumber("amount", Integer.class);
+
+    public final DatePath<java.time.LocalDate> dispatchDeadline = createDate("dispatchDeadline", java.time.LocalDate.class);
+
+    public final kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QItemOrderNumber number;
+
+    public final ListPath<kr.tatine.manibogo_oms_v2.fulfillment.command.domain.option.OptionId, kr.tatine.manibogo_oms_v2.fulfillment.command.domain.option.QOptionId> optionIds = this.<kr.tatine.manibogo_oms_v2.fulfillment.command.domain.option.OptionId, kr.tatine.manibogo_oms_v2.fulfillment.command.domain.option.QOptionId>createList("optionIds", kr.tatine.manibogo_oms_v2.fulfillment.command.domain.option.OptionId.class, kr.tatine.manibogo_oms_v2.fulfillment.command.domain.option.QOptionId.class, PathInits.DIRECT2);
+
+    public final kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QOrderNumber orderNumber;
+
+    public final DatePath<java.time.LocalDate> preferredShipsOn = createDate("preferredShipsOn", java.time.LocalDate.class);
+
+    public final kr.tatine.manibogo_oms_v2.fulfillment.command.domain.product.QProductNumber productNumber;
+
+    public final kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QShippingInfo shippingInfo;
+
+    public final EnumPath<kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.ItemOrderState> state = createEnum("state", kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.ItemOrderState.class);
+
+    public final kr.tatine.manibogo_oms_v2.common.model.QMoney totalPrice;
+
+    public final kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QTrackingInfo trackingInfo;
+
+    public QItemOrder(String variable) {
+        this(ItemOrder.class, forVariable(variable), INITS);
+    }
+
+    public QItemOrder(Path<? extends ItemOrder> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QItemOrder(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QItemOrder(PathMetadata metadata, PathInits inits) {
+        this(ItemOrder.class, metadata, inits);
+    }
+
+    public QItemOrder(Class<? extends ItemOrder> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.number = inits.isInitialized("number") ? new kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QItemOrderNumber(forProperty("number")) : null;
+        this.orderNumber = inits.isInitialized("orderNumber") ? new kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QOrderNumber(forProperty("orderNumber")) : null;
+        this.productNumber = inits.isInitialized("productNumber") ? new kr.tatine.manibogo_oms_v2.fulfillment.command.domain.product.QProductNumber(forProperty("productNumber")) : null;
+        this.shippingInfo = inits.isInitialized("shippingInfo") ? new kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QShippingInfo(forProperty("shippingInfo")) : null;
+        this.totalPrice = inits.isInitialized("totalPrice") ? new kr.tatine.manibogo_oms_v2.common.model.QMoney(forProperty("totalPrice")) : null;
+        this.trackingInfo = inits.isInitialized("trackingInfo") ? new kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QTrackingInfo(forProperty("trackingInfo")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/QItemOrderHistory.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/QItemOrderHistory.java
@@ -1,0 +1,57 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QItemOrderHistory is a Querydsl query type for ItemOrderHistory
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QItemOrderHistory extends EntityPathBase<ItemOrderHistory> {
+
+    private static final long serialVersionUID = 722113946L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QItemOrderHistory itemOrderHistory = new QItemOrderHistory("itemOrderHistory");
+
+    public final DateTimePath<java.time.LocalDateTime> changedAt = createDateTime("changedAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QItemOrderNumber itemOrderNumber;
+
+    public final EnumPath<kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.ItemOrderState> newState = createEnum("newState", kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.ItemOrderState.class);
+
+    public final EnumPath<kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.ItemOrderState> previousState = createEnum("previousState", kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.ItemOrderState.class);
+
+    public QItemOrderHistory(String variable) {
+        this(ItemOrderHistory.class, forVariable(variable), INITS);
+    }
+
+    public QItemOrderHistory(Path<? extends ItemOrderHistory> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QItemOrderHistory(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QItemOrderHistory(PathMetadata metadata, PathInits inits) {
+        this(ItemOrderHistory.class, metadata, inits);
+    }
+
+    public QItemOrderHistory(Class<? extends ItemOrderHistory> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.itemOrderNumber = inits.isInitialized("itemOrderNumber") ? new kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QItemOrderNumber(forProperty("itemOrderNumber")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/QOrder.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/QOrder.java
@@ -1,0 +1,57 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QOrder is a Querydsl query type for Order
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QOrder extends EntityPathBase<Order> {
+
+    private static final long serialVersionUID = -1016044435L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QOrder order = new QOrder("order1");
+
+    public final kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QCustomer customer;
+
+    public final kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QOrderNumber number;
+
+    public final kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QRecipient recipient;
+
+    public final EnumPath<kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.SalesChannel> salesChannel = createEnum("salesChannel", kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.SalesChannel.class);
+
+    public QOrder(String variable) {
+        this(Order.class, forVariable(variable), INITS);
+    }
+
+    public QOrder(Path<? extends Order> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QOrder(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QOrder(PathMetadata metadata, PathInits inits) {
+        this(Order.class, metadata, inits);
+    }
+
+    public QOrder(Class<? extends Order> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.customer = inits.isInitialized("customer") ? new kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QCustomer(forProperty("customer"), inits.get("customer")) : null;
+        this.number = inits.isInitialized("number") ? new kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QOrderNumber(forProperty("number")) : null;
+        this.recipient = inits.isInitialized("recipient") ? new kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.QRecipient(forProperty("recipient"), inits.get("recipient")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/vo/QCustomer.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/vo/QCustomer.java
@@ -1,0 +1,51 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCustomer is a Querydsl query type for Customer
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QCustomer extends BeanPath<Customer> {
+
+    private static final long serialVersionUID = 231139730L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCustomer customer = new QCustomer("customer");
+
+    public final StringPath name = createString("name");
+
+    public final kr.tatine.manibogo_oms_v2.common.model.QPhoneNumber phoneNumber;
+
+    public QCustomer(String variable) {
+        this(Customer.class, forVariable(variable), INITS);
+    }
+
+    public QCustomer(Path<? extends Customer> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCustomer(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCustomer(PathMetadata metadata, PathInits inits) {
+        this(Customer.class, metadata, inits);
+    }
+
+    public QCustomer(Class<? extends Customer> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.phoneNumber = inits.isInitialized("phoneNumber") ? new kr.tatine.manibogo_oms_v2.common.model.QPhoneNumber(forProperty("phoneNumber")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/vo/QItemOrderNumber.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/vo/QItemOrderNumber.java
@@ -1,0 +1,37 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QItemOrderNumber is a Querydsl query type for ItemOrderNumber
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QItemOrderNumber extends BeanPath<ItemOrderNumber> {
+
+    private static final long serialVersionUID = -1738099984L;
+
+    public static final QItemOrderNumber itemOrderNumber1 = new QItemOrderNumber("itemOrderNumber1");
+
+    public final StringPath itemOrderNumber = createString("itemOrderNumber");
+
+    public QItemOrderNumber(String variable) {
+        super(ItemOrderNumber.class, forVariable(variable));
+    }
+
+    public QItemOrderNumber(Path<? extends ItemOrderNumber> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QItemOrderNumber(PathMetadata metadata) {
+        super(ItemOrderNumber.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/vo/QOrderNumber.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/vo/QOrderNumber.java
@@ -1,0 +1,37 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QOrderNumber is a Querydsl query type for OrderNumber
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QOrderNumber extends BeanPath<OrderNumber> {
+
+    private static final long serialVersionUID = 16508419L;
+
+    public static final QOrderNumber orderNumber1 = new QOrderNumber("orderNumber1");
+
+    public final StringPath orderNumber = createString("orderNumber");
+
+    public QOrderNumber(String variable) {
+        super(OrderNumber.class, forVariable(variable));
+    }
+
+    public QOrderNumber(Path<? extends OrderNumber> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QOrderNumber(PathMetadata metadata) {
+        super(OrderNumber.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/vo/QRecipient.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/vo/QRecipient.java
@@ -1,0 +1,57 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QRecipient is a Querydsl query type for Recipient
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QRecipient extends BeanPath<Recipient> {
+
+    private static final long serialVersionUID = 2078883557L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QRecipient recipient = new QRecipient("recipient");
+
+    public final kr.tatine.manibogo_oms_v2.common.model.QAddress address;
+
+    public final StringPath name = createString("name");
+
+    public final kr.tatine.manibogo_oms_v2.common.model.QPhoneNumber phoneNumber1;
+
+    public final kr.tatine.manibogo_oms_v2.common.model.QPhoneNumber phoneNumber2;
+
+    public QRecipient(String variable) {
+        this(Recipient.class, forVariable(variable), INITS);
+    }
+
+    public QRecipient(Path<? extends Recipient> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QRecipient(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QRecipient(PathMetadata metadata, PathInits inits) {
+        this(Recipient.class, metadata, inits);
+    }
+
+    public QRecipient(Class<? extends Recipient> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.address = inits.isInitialized("address") ? new kr.tatine.manibogo_oms_v2.common.model.QAddress(forProperty("address")) : null;
+        this.phoneNumber1 = inits.isInitialized("phoneNumber1") ? new kr.tatine.manibogo_oms_v2.common.model.QPhoneNumber(forProperty("phoneNumber1")) : null;
+        this.phoneNumber2 = inits.isInitialized("phoneNumber2") ? new kr.tatine.manibogo_oms_v2.common.model.QPhoneNumber(forProperty("phoneNumber2")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/vo/QShippingInfo.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/vo/QShippingInfo.java
@@ -1,0 +1,39 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QShippingInfo is a Querydsl query type for ShippingInfo
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QShippingInfo extends BeanPath<ShippingInfo> {
+
+    private static final long serialVersionUID = 1223466800L;
+
+    public static final QShippingInfo shippingInfo = new QShippingInfo("shippingInfo");
+
+    public final EnumPath<ChargeType> chargeType = createEnum("chargeType", ChargeType.class);
+
+    public final EnumPath<ShippingMethod> method = createEnum("method", ShippingMethod.class);
+
+    public QShippingInfo(String variable) {
+        super(ShippingInfo.class, forVariable(variable));
+    }
+
+    public QShippingInfo(Path<? extends ShippingInfo> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QShippingInfo(PathMetadata metadata) {
+        super(ShippingInfo.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/vo/QTrackingInfo.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/vo/QTrackingInfo.java
@@ -1,0 +1,39 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QTrackingInfo is a Querydsl query type for TrackingInfo
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QTrackingInfo extends BeanPath<TrackingInfo> {
+
+    private static final long serialVersionUID = -261999687L;
+
+    public static final QTrackingInfo trackingInfo = new QTrackingInfo("trackingInfo");
+
+    public final StringPath companyName = createString("companyName");
+
+    public final StringPath trackingNumber = createString("trackingNumber");
+
+    public QTrackingInfo(String variable) {
+        super(TrackingInfo.class, forVariable(variable));
+    }
+
+    public QTrackingInfo(Path<? extends TrackingInfo> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QTrackingInfo(PathMetadata metadata) {
+        super(TrackingInfo.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/product/QPriority.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/product/QPriority.java
@@ -1,0 +1,37 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.command.domain.product;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QPriority is a Querydsl query type for Priority
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QPriority extends BeanPath<Priority> {
+
+    private static final long serialVersionUID = 277529727L;
+
+    public static final QPriority priority1 = new QPriority("priority1");
+
+    public final NumberPath<Integer> priority = createNumber("priority", Integer.class);
+
+    public QPriority(String variable) {
+        super(Priority.class, forVariable(variable));
+    }
+
+    public QPriority(Path<? extends Priority> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QPriority(PathMetadata metadata) {
+        super(Priority.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/product/QProduct.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/product/QProduct.java
@@ -1,0 +1,54 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.command.domain.product;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QProduct is a Querydsl query type for Product
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QProduct extends EntityPathBase<Product> {
+
+    private static final long serialVersionUID = -2064041292L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QProduct product = new QProduct("product");
+
+    public final StringPath name = createString("name");
+
+    public final QPriority priority;
+
+    public final QProductNumber productNumber;
+
+    public QProduct(String variable) {
+        this(Product.class, forVariable(variable), INITS);
+    }
+
+    public QProduct(Path<? extends Product> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QProduct(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QProduct(PathMetadata metadata, PathInits inits) {
+        this(Product.class, metadata, inits);
+    }
+
+    public QProduct(Class<? extends Product> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.priority = inits.isInitialized("priority") ? new QPriority(forProperty("priority")) : null;
+        this.productNumber = inits.isInitialized("productNumber") ? new QProductNumber(forProperty("productNumber")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/product/QProduct.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/product/QProduct.java
@@ -24,9 +24,9 @@ public class QProduct extends EntityPathBase<Product> {
 
     public final StringPath name = createString("name");
 
-    public final QPriority priority;
+    public final QProductNumber number;
 
-    public final QProductNumber productNumber;
+    public final QPriority priority;
 
     public QProduct(String variable) {
         this(Product.class, forVariable(variable), INITS);
@@ -46,8 +46,8 @@ public class QProduct extends EntityPathBase<Product> {
 
     public QProduct(Class<? extends Product> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
+        this.number = inits.isInitialized("number") ? new QProductNumber(forProperty("number")) : null;
         this.priority = inits.isInitialized("priority") ? new QPriority(forProperty("priority")) : null;
-        this.productNumber = inits.isInitialized("productNumber") ? new QProductNumber(forProperty("productNumber")) : null;
     }
 
 }

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/product/QProductNumber.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/product/QProductNumber.java
@@ -1,0 +1,37 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.command.domain.product;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QProductNumber is a Querydsl query type for ProductNumber
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QProductNumber extends BeanPath<ProductNumber> {
+
+    private static final long serialVersionUID = 222636829L;
+
+    public static final QProductNumber productNumber1 = new QProductNumber("productNumber1");
+
+    public final StringPath productNumber = createString("productNumber");
+
+    public QProductNumber(String variable) {
+        super(ProductNumber.class, forVariable(variable));
+    }
+
+    public QProductNumber(Path<? extends ProductNumber> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QProductNumber(PathMetadata metadata) {
+        super(ProductNumber.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/QFulfillmentDto.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/QFulfillmentDto.java
@@ -1,0 +1,85 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.query.dto;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QFulfillmentDto is a Querydsl query type for FulfillmentDto
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QFulfillmentDto extends EntityPathBase<FulfillmentDto> {
+
+    private static final long serialVersionUID = -904599199L;
+
+    public static final QFulfillmentDto fulfillmentDto = new QFulfillmentDto("fulfillmentDto");
+
+    public final StringPath adminMemo = createString("adminMemo");
+
+    public final NumberPath<Integer> amount = createNumber("amount", Integer.class);
+
+    public final DatePath<java.time.LocalDate> cancelledOn = createDate("cancelledOn", java.time.LocalDate.class);
+
+    public final DatePath<java.time.LocalDate> confirmedOn = createDate("confirmedOn", java.time.LocalDate.class);
+
+    public final StringPath customerMemo = createString("customerMemo");
+
+    public final StringPath customerName = createString("customerName");
+
+    public final DatePath<java.time.LocalDate> dispatchDeadline = createDate("dispatchDeadline", java.time.LocalDate.class);
+
+    public final DatePath<java.time.LocalDate> dispatchedOn = createDate("dispatchedOn", java.time.LocalDate.class);
+
+    public final NumberPath<Integer> itemOrderBundleCount = createNumber("itemOrderBundleCount", Integer.class);
+
+    public final StringPath itemOrderNumber = createString("itemOrderNumber");
+
+    public final EnumPath<kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.ItemOrderState> itemOrderState = createEnum("itemOrderState", kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.ItemOrderState.class);
+
+    public final StringPath optionInfo = createString("optionInfo");
+
+    public final StringPath orderNumber = createString("orderNumber");
+
+    public final DatePath<java.time.LocalDate> placedOn = createDate("placedOn", java.time.LocalDate.class);
+
+    public final DatePath<java.time.LocalDate> preferredShipsOn = createDate("preferredShipsOn", java.time.LocalDate.class);
+
+    public final StringPath productName = createString("productName");
+
+    public final DatePath<java.time.LocalDate> purchasedOn = createDate("purchasedOn", java.time.LocalDate.class);
+
+    public final StringPath purchaseMemo = createString("purchaseMemo");
+
+    public final StringPath recipientName = createString("recipientName");
+
+    public final DatePath<java.time.LocalDate> refundedOn = createDate("refundedOn", java.time.LocalDate.class);
+
+    public final EnumPath<kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.SalesChannel> salesChannel = createEnum("salesChannel", kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.SalesChannel.class);
+
+    public final DatePath<java.time.LocalDate> shippedOn = createDate("shippedOn", java.time.LocalDate.class);
+
+    public final StringPath shippingMemo = createString("shippingMemo");
+
+    public final StringPath shippingRegionName = createString("shippingRegionName");
+
+    public final StringPath shippingTrackingNumber = createString("shippingTrackingNumber");
+
+    public QFulfillmentDto(String variable) {
+        super(FulfillmentDto.class, forVariable(variable));
+    }
+
+    public QFulfillmentDto(Path<? extends FulfillmentDto> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QFulfillmentDto(PathMetadata metadata) {
+        super(FulfillmentDto.class, metadata);
+    }
+
+}
+

--- a/src/main/java/kr/tatine/manibogo_oms_v2/ManibogoOmsV2Application.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/ManibogoOmsV2Application.java
@@ -2,6 +2,8 @@ package kr.tatine.manibogo_oms_v2;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableAsync

--- a/src/main/java/kr/tatine/manibogo_oms_v2/common/config/QueryDslConfiguration.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/common/config/QueryDslConfiguration.java
@@ -1,0 +1,20 @@
+package kr.tatine.manibogo_oms_v2.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfiguration {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/command/application/SyncExternalItemOrderService.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/command/application/SyncExternalItemOrderService.java
@@ -116,7 +116,7 @@ public class SyncExternalItemOrderService {
 
     private Recipient createRecipient(ExternalItemOrderRequest command) {
         return new Recipient(
-                command.productName(),
+                command.recipientName(),
                 new PhoneNumber(command.recipientPhoneNumber1()),
                 new PhoneNumber(command.recipientPhoneNumber2()),
                 new Address(

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/vo/Recipient.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/order/model/vo/Recipient.java
@@ -16,6 +16,7 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Recipient {
 
+    @Column(name = "recipient_name")
     private String name;
 
     @AttributeOverride(

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/product/Product.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/command/domain/product/Product.java
@@ -13,15 +13,15 @@ import lombok.ToString;
 public class Product {
 
     @EmbeddedId
-    private ProductNumber productNumber;
+    private ProductNumber number;
 
     private String name;
 
     @Embedded
     private Priority priority;
 
-    public Product(ProductNumber productNumber, String name, Priority priority) {
-        this.productNumber = productNumber;
+    public Product(ProductNumber number, String name, Priority priority) {
+        this.number = number;
         this.name = name;
         this.priority = priority;
     }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/infra/QueryDslFulfillmentDao.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/infra/QueryDslFulfillmentDao.java
@@ -1,0 +1,42 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.infra;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.tatine.manibogo_oms_v2.fulfillment.query.dao.FulfillmentDao;
+import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.FulfillmentDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static kr.tatine.manibogo_oms_v2.fulfillment.query.dto.QFulfillmentDto.fulfillmentDto;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryDslFulfillmentDao implements FulfillmentDao {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<FulfillmentDto> findAll(Pageable pageable) {
+
+        final List<FulfillmentDto> content = queryFactory
+                .selectFrom(fulfillmentDto)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(fulfillmentDto.itemOrderNumber.desc())
+                .fetch();
+
+        final JPAQuery<Long> countQuery = queryFactory
+                .select(fulfillmentDto.count())
+                .from(fulfillmentDto);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dao/FulfillmentDao.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dao/FulfillmentDao.java
@@ -1,0 +1,11 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.query.dao;
+
+import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.FulfillmentDto;
+
+import java.util.List;
+
+public interface FulfillmentDao {
+
+    List<FulfillmentDto> findAll();
+
+}

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dao/FulfillmentDao.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dao/FulfillmentDao.java
@@ -1,11 +1,10 @@
 package kr.tatine.manibogo_oms_v2.fulfillment.query.dao;
 
 import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.FulfillmentDto;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface FulfillmentDao {
-
-    List<FulfillmentDto> findAll();
+public interface FulfillmentDao extends JpaRepository<FulfillmentDto, String> {
 
 }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dao/FulfillmentDao.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dao/FulfillmentDao.java
@@ -1,10 +1,11 @@
 package kr.tatine.manibogo_oms_v2.fulfillment.query.dao;
 
 import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.FulfillmentDto;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
-import java.util.List;
+public interface FulfillmentDao {
 
-public interface FulfillmentDao extends JpaRepository<FulfillmentDto, String> {
+    Page<FulfillmentDto> findAll(Pageable pageable);
 
 }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/FulfillmentDto.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/FulfillmentDto.java
@@ -3,36 +3,36 @@ package kr.tatine.manibogo_oms_v2.fulfillment.query.dto;
 import kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.ItemOrderState;
 import kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.SalesChannel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
 @Getter
-@Setter
 @ToString
+@NoArgsConstructor
 public class FulfillmentDto {
 
-    private boolean isRowSelected;
-
-    private SalesChannel salesChannel;
-
-    private ItemOrderState orderState;
+    private String itemOrderNumber;
 
     private String orderNumber;
 
+    private SalesChannel salesChannel;
+
+    private ItemOrderState itemOrderState;
+
     private String productName;
 
-    private int shippingBundleCount;
+    private int shippingBundleCount = 1;
 
     private int amount;
 
-    private String shippingRegionName;
+    private String shippingRegionName = "아직";
 
-    private String buyerName;
+    private String customerName;
 
-    private String receiverName;
+    private String recipientName;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate orderPlacedOn;

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/ui/FulfillmentController.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/ui/FulfillmentController.java
@@ -39,17 +39,6 @@ public class FulfillmentController {
 
         FulfillmentListDto fulfillmentListDto = new FulfillmentListDto();
 
-        fulfillmentListDto.setFulfillmentList(List.of(
-                createRowDto(ItemOrderState.PLACED, SalesChannel.SMART_STORE),
-                createRowDto(ItemOrderState.PURCHASED, SalesChannel.SMART_STORE),
-                createRowDto(ItemOrderState.DISPATCHED, SalesChannel.SMART_STORE),
-                createRowDto(ItemOrderState.SHIPPED, SalesChannel.SMART_STORE),
-                createRowDto(ItemOrderState.CONFIRMED, SalesChannel.SMART_STORE),
-                createRowDto(ItemOrderState.CANCELLED, SalesChannel.SMART_STORE),
-                createRowDto(ItemOrderState.REFUNDED, SalesChannel.SMART_STORE),
-                createRowDto(ItemOrderState.PLACED, SalesChannel.LOCAL)
-        ));
-
         model.addAttribute("fulfillmentList", fulfillmentListDto);
 
         return "fulfillment";
@@ -62,28 +51,6 @@ public class FulfillmentController {
         }
 
         return "redirect:/v2/fulfillment";
-    }
-
-    private FulfillmentDto createRowDto(ItemOrderState orderState, SalesChannel salesChannel) {
-        FulfillmentDto fulfillmentDto = new FulfillmentDto();
-
-        fulfillmentDto.setRowSelected(false);
-        fulfillmentDto.setSalesChannel(salesChannel);
-        fulfillmentDto.setOrderState(orderState);
-        fulfillmentDto.setOrderNumber("2025051637129311");
-        fulfillmentDto.setProductName("베아투스 매트리스 [사이즈: 1500X2000]");
-        fulfillmentDto.setAmount(2);
-        fulfillmentDto.setShippingBundleCount(2);
-        fulfillmentDto.setShippingRegionName("경기");
-        fulfillmentDto.setBuyerName("홍길동");
-        fulfillmentDto.setReceiverName("홍길동");
-        fulfillmentDto.setOrderPlacedOn(LocalDate.parse("2025-05-18"));
-        fulfillmentDto.setDispatchDeadlineOn(LocalDate.parse("2025-06-09"));
-        fulfillmentDto.setPurchasedOn(LocalDate.parse("2025-05-19"));
-        fulfillmentDto.setDispatchedOn(LocalDate.parse("2025-05-19"));
-        fulfillmentDto.setShippedOn(LocalDate.parse("2025-05-20"));
-        fulfillmentDto.setPurchaseMemo("최대한 빨리 제작요청");
-        return fulfillmentDto;
     }
 
 }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/ui/FulfillmentController.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/ui/FulfillmentController.java
@@ -2,10 +2,13 @@ package kr.tatine.manibogo_oms_v2.fulfillment.ui;
 
 import kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.ItemOrderState;
 import kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.SalesChannel;
+import kr.tatine.manibogo_oms_v2.fulfillment.query.dao.FulfillmentDao;
 import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.FulfillmentDto;
 import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.FulfillmentListDto;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -18,7 +21,10 @@ import java.util.List;
 @Slf4j
 @Controller
 @RequestMapping("/v2/fulfillment")
+@RequiredArgsConstructor
 public class FulfillmentController {
+
+    private final FulfillmentDao fulfillmentDao;
 
     @ModelAttribute("itemOrderStates")
     public ItemOrderState[] orderStates() {
@@ -31,6 +37,7 @@ public class FulfillmentController {
     }
 
     @GetMapping
+    @Transactional(readOnly = true)
     public String fulfillment(
             Model model,
             @ModelAttribute SynchronizeResponse synchronizeResponse) {
@@ -38,6 +45,8 @@ public class FulfillmentController {
         model.addAttribute("synchronizeResponse", synchronizeResponse);
 
         FulfillmentListDto fulfillmentListDto = new FulfillmentListDto();
+
+        fulfillmentListDto.setFulfillmentList(fulfillmentDao.findAll());
 
         model.addAttribute("fulfillmentList", fulfillmentListDto);
 

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/ui/FulfillmentController.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/ui/FulfillmentController.java
@@ -7,6 +7,10 @@ import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.FulfillmentDto;
 import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.FulfillmentListDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
@@ -16,7 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.time.LocalDate;
-import java.util.List;
+import java.util.*;
 
 @Slf4j
 @Controller
@@ -39,18 +43,82 @@ public class FulfillmentController {
     @GetMapping
     @Transactional(readOnly = true)
     public String fulfillment(
+            @PageableDefault(sort = "item_order_number", direction = Sort.Direction.DESC) Pageable pageable,
             Model model,
             @ModelAttribute SynchronizeResponse synchronizeResponse) {
 
         model.addAttribute("synchronizeResponse", synchronizeResponse);
 
+        final Page<FulfillmentDto> page = fulfillmentDao.findAll(pageable);
+        model.addAttribute("page", page);
+
+        calculatePageAttribute(model, page);
+
         FulfillmentListDto fulfillmentListDto = new FulfillmentListDto();
-
-        fulfillmentListDto.setFulfillmentList(fulfillmentDao.findAll());
-
+        fulfillmentListDto.setFulfillmentList(page.getContent());
         model.addAttribute("fulfillmentList", fulfillmentListDto);
 
         return "fulfillment";
+    }
+
+    private void calculatePageAttribute(Model model, Page<FulfillmentDto> page) {
+        // 1-based 현재 페이지 번호
+        int currentPage1Based = page.getPageable().getPageNumber() + 1;
+        // 1-based 총 페이지 수
+        int totalPages1Based = page.getTotalPages();
+
+        // --- 페이징 UI에 표시할 페이지 번호 목록 계산 로직 ---
+        List<Integer> pageNumbers = new ArrayList<>();
+        final int DISPLAY_MIDDLE_RANGE = 2; // 현재 페이지를 기준으로 앞뒤로 보여줄 페이지 개수 (예: 2 -> 총 5개)
+        final int MAX_DISPLAY_PAGES = 5; // 표시할 페이지 번호의 최대 개수 (1, ... , totalPage 포함하지 않음)
+
+        // 항상 첫 페이지(1) 추가
+        if (totalPages1Based > 0) {
+            pageNumbers.add(1);
+        }
+
+        // 중간 페이지 범위 계산
+        int startMiddlePage = Math.max(2, currentPage1Based - DISPLAY_MIDDLE_RANGE);
+        int endMiddlePage = Math.min(totalPages1Based - 1, currentPage1Based + DISPLAY_MIDDLE_RANGE);
+
+        // "..." (왼쪽) 표시 여부
+        if (startMiddlePage > 2) { // 1 다음에 2가 아닌 다른 페이지가 오면 "..."
+            // "..." 을 나타내는 특별한 값 (예: -1 또는 null)을 리스트에 추가하거나,
+            // 템플릿에서 직접 조건부 렌더링으로 처리하는게 더 일반적입니다.
+            // 여기서는 템플릿에서 처리할 수 있도록 startMiddlePage와 endMiddlePage만 전달합니다.
+        }
+
+        // 중간 페이지 번호 추가
+        for (int i = startMiddlePage; i <= endMiddlePage; i++) {
+            if (i > 1 && i < totalPages1Based) { // 1과 마지막 페이지는 이미 추가했으므로 제외
+                pageNumbers.add(i);
+            }
+        }
+
+        // "..." (오른쪽) 표시 여부
+        if (endMiddlePage < totalPages1Based - 1) { // 마지막 페이지 이전에 마지막-1 페이지가 아닌 다른 페이지가 오면 "..."
+            // 템플릿에서 조건부 렌더링
+        }
+
+        // 항상 마지막 페이지 추가 (총 페이지 수가 1이 아니고 이미 1이 아닌 경우)
+        if (totalPages1Based > 1 && !pageNumbers.contains(totalPages1Based)) {
+            pageNumbers.add(totalPages1Based);
+        }
+
+
+
+        // --- 복합 페이징 로직 끝 ---
+        model.addAttribute("pageNumbers", pageNumbers); // UI에 표시할 페이지 번호 목록 (1-based)
+        model.addAttribute("currentPage", currentPage1Based); // 1-based 현재 페이지
+        model.addAttribute("pageSize", page.getPageable().getPageSize());
+        model.addAttribute("totalPage", totalPages1Based); // 1-based 총 페이지 수 (템플릿 마지막 버튼 링크에 필요)
+
+
+
+        // "..." 표시 여부를 위한 플래그 (템플릿에서 사용)
+        model.addAttribute("showLeftDots", startMiddlePage > 2);
+        model.addAttribute("showRightDots", endMiddlePage < totalPages1Based - 1);
+
     }
 
     @PostMapping("/edit")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,14 +13,14 @@ spring:
       on-profile: local
 
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:smartstore_order_management;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1
-    username: sa
-    password:
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://localhost:3306/manibogo_oms_v2
+    username: root
+    password: 3520
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
 
     properties:
       hibernate:

--- a/src/main/resources/templates/fulfillment.html
+++ b/src/main/resources/templates/fulfillment.html
@@ -67,13 +67,12 @@
             </thead>
 
             <tbody th:each="fulfillment : *{getFulfillmentList}"
-                   th:class="|table-row ${fulfillment.orderState.name().toLowerCase()}|">
+                   th:class="|table-row ${fulfillment.getItemOrderState.name().toLowerCase()}|">
             <tr>
                 <td class="td">
                     <input type="checkbox"
                            aria-label="선택"
-                           class="form-check-input chk-select-row"
-                           th:field="*{fulfillmentList[__${fulfillmentStat.index}__].rowSelected}">
+                           class="form-check-input chk-select-row">
                 </td>
 
                 <td class="td">
@@ -81,7 +80,7 @@
                         <option th:each="itemOrderState : ${itemOrderStates}"
                                 th:value="${itemOrderState}"
                                 th:text="${itemOrderState.description}"
-                                th:selected="${itemOrderState} == *{fulfillmentList[__${fulfillmentStat.index}__].orderState}">
+                                th:selected="${itemOrderState} == *{fulfillmentList[__${fulfillmentStat.index}__].getItemOrderState}">
                         </option>
                     </select>
                 </td>
@@ -122,10 +121,10 @@
                 <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].shippingRegionName}">지역</td>
 
                 <td class="td">
-                    <a href="#" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].buyerName}">구매자</a>
+                    <a href="#" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].customerName}">구매자</a>
                 </td>
 
-                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].receiverName}">수취인</td>
+                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].recipientName}">수취인</td>
 
                 <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].orderPlacedOn}">주문일자</td>
 

--- a/src/main/resources/templates/fulfillment.html
+++ b/src/main/resources/templates/fulfillment.html
@@ -106,8 +106,8 @@
 
                 <td class="td">
                     <a href="#"
-                       th:classappend="*{fulfillmentList[__${fulfillmentStat.index}__].shippingBundleCount > 1} ? 'accent' : ''"
-                       th:text="*{fulfillmentList[__${fulfillmentStat.index}__].shippingBundleCount}">
+                       th:classappend="*{fulfillmentList[__${fulfillmentStat.index}__].itemOrderBundleCount > 1} ? 'accent' : ''"
+                       th:text="*{fulfillmentList[__${fulfillmentStat.index}__].itemOrderBundleCount}">
                         합배송수
                     </a>
                 </td>
@@ -126,16 +126,16 @@
 
                 <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].recipientName}">수취인</td>
 
-                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].orderPlacedOn}">주문일자</td>
+                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].getPlacedOn}">주문일자</td>
 
                 <td class="td">
                     <input class="form-control form-control-sm" type="date" aria-label="발송기한"
-                           th:field="*{fulfillmentList[__${fulfillmentStat.index}__].dispatchDeadlineOn}">
+                           th:field="*{fulfillmentList[__${fulfillmentStat.index}__].dispatchDeadline}">
                 </td>
 
                 <td class="td">
                     <input class="form-control form-control-sm" type="date" aria-label="희망배송일자"
-                           th:value="*{fulfillmentList[__${fulfillmentStat.index}__].preferShipsOn}">
+                           th:value="*{fulfillmentList[__${fulfillmentStat.index}__].preferredShipsOn}">
                 </td>
 
                 <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].purchasedOn}">발주일자</td>
@@ -152,14 +152,14 @@
 
                 <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].confirmedOn}">확정일자</td>
 
-                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].canceledOn}">취소일자</td>
+                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].cancelledOn}">취소일자</td>
 
                 <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].refundedOn}">반품일자</td>
             </tr>
             <tr>
                 <td class="td"></td>
 
-                <td colspan="4" class="td text-left" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].buyerMemo}">고객메모</td>
+                <td colspan="4" class="td text-left" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].customerMemo}">고객메모</td>
 
                 <td class="td" colspan="6">
                     <input class="form-control form-control-sm" type="text"

--- a/src/main/resources/templates/fulfillment.html
+++ b/src/main/resources/templates/fulfillment.html
@@ -67,8 +67,10 @@
             </thead>
 
             <tbody th:each="fulfillment : *{getFulfillmentList}"
-                   th:class="|table-row ${fulfillment.getItemOrderState.name().toLowerCase()}|">
-            <tr>
+                   th:class="|table-row ${fulfillment.getItemOrderState.name().toLowerCase()}|"
+                    th:classappend="${fulfillmentStat.even ? 'table-light' : ''}"
+            >
+            <tr >
                 <td class="td">
                     <input type="checkbox"
                            aria-label="선택"

--- a/src/main/resources/templates/fulfillment.html
+++ b/src/main/resources/templates/fulfillment.html
@@ -180,9 +180,46 @@
             </tr>
             </tbody>
         </table>
-
     </form>
 
+    <nav aria-label="Page navigation" th:with="sort=${#strings.listJoin(page.pageable.sort.toString().split(': '), ',')}">
+        <ul class="pagination justify-content-center">
+
+            <li class="page-item" th:classappend="${page.first ? 'disabled' : ''}">
+                <a class="page-link" th:href="@{/v2/fulfillment(page=${page.number - 1}, size=${pageSize}, sort=${sort})}" aria-label="이전 페이지로">
+                    <span aria-hidden="true">&laquo;</span>
+                </a>
+            </li>
+
+            <li class="page-item" th:classappend="${1 == currentPage ? 'active' : ''}">
+                <a class="page-link" th:href="@{/v2/fulfillment(page=0, size=${pageSize}, sort=${sort})}" th:text="1" th:aria-label="|1번 페이지로|"></a>
+            </li>
+
+            <li class="page-item disabled" th:if="${showLeftDots}">
+                <a class="page-link" href="#">...</a>
+            </li>
+
+            <li class="page-item" th:each="i : ${pageNumbers}"
+                th:if="${i != 1 and i != totalPage}"
+                th:classappend="${i == currentPage ? 'active' : ''}">
+                <a class="page-link" th:href="@{/v2/fulfillment(page=${i - 1}, size=${pageSize}, sort=${sort})}" th:text="${i}" th:aria-label="|${i}번 페이지로|"></a>
+            </li>
+
+            <li class="page-item disabled" th:if="${showRightDots}">
+                <a class="page-link" href="#">...</a>
+            </li>
+
+            <li class="page-item" th:if="${totalPage > 1}" th:classappend="${totalPage == currentPage ? 'active' : ''}">
+                <a class="page-link" th:href="@{/v2/fulfillment(page=${totalPage - 1}, size=${pageSize}, sort=${sort})}" th:text="${totalPage}" th:aria-label="|${totalPage}번 페이지로|"></a>
+            </li>
+
+            <li class="page-item" th:classappend="${page.last ? 'disabled' : ''}">
+                <a class="page-link" th:href="@{/v2/fulfillment(page=${page.number + 1}, size=${pageSize}, sort=${sort})}" aria-label="다음 페이지로">
+                    <span aria-hidden="true">&raquo;</span>
+                </a>
+            </li>
+        </ul>
+    </nav>
 </section>
 </body>
 


### PR DESCRIPTION

## 관련 이슈
- close #56
- close #49 
- close #50 

## 작업 목록
### 풀필먼트 조회 모델 & 페이징 쿼리 구현
- [x] 풀필먼트 조회 모델 구현 기술 선택: `QueryDSL vs Native Query`
    - 조회와 페이징, 정렬 등의 구현 기술을 분리하였음
        - **조회:** 인라인 뷰, 문자열 조합 등 복잡한 쿼리가 많아 `Native Query` 을 사용
        - **페이징, 정렬**: 구현이 간단한 `QueryDSL` 선택
- [x] 풀필먼트 조회 모델 쿼리 로직 구현
    - 조회를 위한 `FulfillmentDto` 에 `@Subselect` 를 이용해 Hibernate 가상 뷰를 생성하였음
    - 이를 `Q-Class`로  `QueryDSL`에서 사용해 페이징 및 정렬 구현

### 버그 해결
- [x] 스마트스토어 주문연동 시 수취인 이름을 잘못 입력함

### 풀필먼트 UI 수정
- [x] 행 구분을 위해 짝수 행에 회색 배경 부여

### 로컬 환경 데이터베이스 구성
- [x] 로컬 환경을 위한 데이터베이스 기술 선택: `H2 vs MariaDB`
    - `MariaDB`를 선택하였음. `Spring Devtools`로 `live Reload` 사용하니 자꾸 데이터가 초기화됨
    - `H2` 임베디드 모드가 있지만, 어차피 띄울꺼면 DB 관리 도구 사용이 가능한 `MariaDB` 사용하는게 더 좋음

