### PR TITLE
Feature: 동적 페이지네이션 및 정렬

### DIFF
--- a/src/main/java/kr/tatine/manibogo_oms_v2/common/utils/QueryUtilsConfiguration.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/common/utils/QueryUtilsConfiguration.java
@@ -1,0 +1,20 @@
+package kr.tatine.manibogo_oms_v2.common.utils;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.util.function.BiFunction;
+
+@Configuration
+public class QueryUtilsConfiguration {
+
+    @Bean
+    public BiFunction<String, String, String> replaceOrAddParam() {
+        return (paramName, newValue) -> ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .replaceQueryParam(paramName, newValue)
+                .toUriString();
+    }
+
+}

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/infra/QueryDslFulfillmentDao.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/infra/QueryDslFulfillmentDao.java
@@ -2,7 +2,7 @@ package kr.tatine.manibogo_oms_v2.fulfillment.infra;
 
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.core.types.Path;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.tatine.manibogo_oms_v2.fulfillment.query.dao.FulfillmentDao;
@@ -10,9 +10,11 @@ import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.FulfillmentDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static kr.tatine.manibogo_oms_v2.fulfillment.query.dto.QFulfillmentDto.fulfillmentDto;
@@ -30,7 +32,7 @@ public class QueryDslFulfillmentDao implements FulfillmentDao {
                 .selectFrom(fulfillmentDto)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .orderBy(fulfillmentDto.itemOrderNumber.desc())
+                .orderBy(getOrderSpecifiers(pageable.getSort()))
                 .fetch();
 
         final JPAQuery<Long> countQuery = queryFactory
@@ -39,4 +41,44 @@ public class QueryDslFulfillmentDao implements FulfillmentDao {
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(final Sort sort) {
+
+        final ArrayList<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+        final OrderSpecifier<String> defaultOrderSpecifier = fulfillmentDto.itemOrderNumber.desc();
+
+        for (final Sort.Order order : sort) {
+            final Order direction = order.isAscending()
+                    ? Order.ASC
+                    : Order.DESC;
+
+            final Path<?> propertyPath = getPropertyPath(order.getProperty());
+
+            if (propertyPath == null) continue;
+
+            orderSpecifiers.add(new OrderSpecifier(direction, propertyPath));
+        }
+
+        orderSpecifiers.add(defaultOrderSpecifier);
+
+        return orderSpecifiers.toArray(new OrderSpecifier[0]);
+    }
+
+    private Path<?> getPropertyPath(String property) {
+        return switch (property) {
+            case "shippingRegionName" -> fulfillmentDto.shippingRegionName;
+            case "placedOn" -> fulfillmentDto.placedOn;
+            case "dispatchDeadline" -> fulfillmentDto.dispatchDeadline;
+            case "preferredShipsOn" -> fulfillmentDto.preferredShipsOn;
+            case "purchasedOn" -> fulfillmentDto.purchasedOn;
+            case "dispatchedOn" -> fulfillmentDto.dispatchedOn;
+            case "shippedOn" -> fulfillmentDto.shippedOn;
+            case "confirmedOn" -> fulfillmentDto.confirmedOn;
+            case "cancelledOn" -> fulfillmentDto.cancelledOn;
+            case "refundedOn" -> fulfillmentDto.refundedOn;
+            default -> null;
+        };
+    }
+
 }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/infra/QueryDslFulfillmentDao.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/infra/QueryDslFulfillmentDao.java
@@ -7,6 +7,7 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.tatine.manibogo_oms_v2.fulfillment.query.dao.FulfillmentDao;
 import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.FulfillmentDto;
+import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.FulfillmentSortParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -66,19 +67,23 @@ public class QueryDslFulfillmentDao implements FulfillmentDao {
     }
 
     private Path<?> getPropertyPath(String property) {
-        return switch (property) {
-            case "shippingRegionName" -> fulfillmentDto.shippingRegionName;
-            case "placedOn" -> fulfillmentDto.placedOn;
-            case "dispatchDeadline" -> fulfillmentDto.dispatchDeadline;
-            case "preferredShipsOn" -> fulfillmentDto.preferredShipsOn;
-            case "purchasedOn" -> fulfillmentDto.purchasedOn;
-            case "dispatchedOn" -> fulfillmentDto.dispatchedOn;
-            case "shippedOn" -> fulfillmentDto.shippedOn;
-            case "confirmedOn" -> fulfillmentDto.confirmedOn;
-            case "cancelledOn" -> fulfillmentDto.cancelledOn;
-            case "refundedOn" -> fulfillmentDto.refundedOn;
-            default -> null;
-        };
+        try {
+            return switch (FulfillmentSortParam.valueOf(property)) {
+                case SHIPPING_REGION_NAME -> fulfillmentDto.shippingRegionName;
+                case PLACED_ON -> fulfillmentDto.placedOn;
+                case DISPATCH_DEADLINE -> fulfillmentDto.dispatchDeadline;
+                case PREFERRED_SHIPS_ON -> fulfillmentDto.preferredShipsOn;
+                case PURCHASED_ON -> fulfillmentDto.purchasedOn;
+                case DISPATCHED_ON -> fulfillmentDto.dispatchedOn;
+                case SHIPPED_ON -> fulfillmentDto.shippedOn;
+                case CANCELLED_ON -> fulfillmentDto.confirmedOn;
+                case CONFIRMED_ON -> fulfillmentDto.cancelledOn;
+                case REFUNDED_ON -> fulfillmentDto.refundedOn;
+            };
+
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
     }
 
 }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/FulfillmentDto.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/FulfillmentDto.java
@@ -54,7 +54,7 @@ FROM
         SELECT
             io_opt.item_order_number,
             GROUP_CONCAT(
-                CONCAT(opt.option_key, ': ', opt.`label`)
+                opt.`label`
                 ORDER BY
                     opt.option_key,
                     opt.option_value SEPARATOR ', '
@@ -66,7 +66,7 @@ FROM
         GROUP BY
             io_opt.item_order_number
     ) AS option_agg ON io.item_order_number = option_agg.item_order_number
-    -- 주문별 아이템 개수 미리 집계 View
+    -- 주문별 아이템 개수 집계 View
     LEFT JOIN (
         SELECT
             item_order.order_number,

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/FulfillmentSortParam.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/FulfillmentSortParam.java
@@ -1,0 +1,16 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.query.dto;
+
+public enum FulfillmentSortParam {
+
+    SHIPPING_REGION_NAME,
+    PLACED_ON,
+    DISPATCH_DEADLINE,
+    PREFERRED_SHIPS_ON,
+    PURCHASED_ON,
+    DISPATCHED_ON,
+    SHIPPED_ON,
+    CONFIRMED_ON,
+    CANCELLED_ON,
+    REFUNDED_ON;
+
+}

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/ui/FulfillmentController.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/ui/FulfillmentController.java
@@ -43,7 +43,7 @@ public class FulfillmentController {
     @GetMapping
     @Transactional(readOnly = true)
     public String fulfillment(
-            @PageableDefault(sort = "item_order_number", direction = Sort.Direction.DESC) Pageable pageable,
+            @PageableDefault Pageable pageable,
             Model model,
             @ModelAttribute SynchronizeResponse synchronizeResponse) {
 

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/ui/FulfillmentController.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/ui/FulfillmentController.java
@@ -5,6 +5,7 @@ import kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.Sales
 import kr.tatine.manibogo_oms_v2.fulfillment.query.dao.FulfillmentDao;
 import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.FulfillmentDto;
 import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.FulfillmentListDto;
+import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.FulfillmentSortParam;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -19,7 +20,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.time.LocalDate;
 import java.util.*;
 
 @Slf4j
@@ -58,7 +58,40 @@ public class FulfillmentController {
         fulfillmentListDto.setFulfillmentList(page.getContent());
         model.addAttribute("fulfillmentList", fulfillmentListDto);
 
+        model.addAttribute("nextSortParams", getNextSortParams(pageable.getSort()));
+
         return "fulfillment";
+    }
+
+    private Map<String, String> getNextSortParams(Sort currentSort) {
+
+        Map<String , String> nextSortParams = new HashMap<>();
+
+        for (FulfillmentSortParam sortField : FulfillmentSortParam.values()) {
+
+            final Optional<Sort.Order> optionalOrder = currentSort.stream()
+                    .filter(order -> order.getProperty().equals(sortField.name()))
+                    .findFirst();
+
+            // 현재 정렬 없음 -> 다음은 내림차순 (DESC)
+            if (optionalOrder.isEmpty()) {
+                nextSortParams.put(sortField.name(), sortField.name() + ",DESC");
+                continue;
+            }
+
+            final Sort.Order order = optionalOrder.get();
+
+            // 현재 오름차순(ASC) -> 정렬 해제(UNSORTED)
+            if (order.getDirection() == Sort.Direction.ASC) {
+                nextSortParams.put(sortField.name(), "UNSORTED");
+                continue;
+            }
+
+            // 현재 내림차순(DESC) -> 다음은 오름차순(ASC)
+            nextSortParams.put(sortField.name(), sortField.name() + ",ASC");
+        }
+
+        return nextSortParams;
     }
 
     private void calculatePageAttribute(Model model, Page<FulfillmentDto> page) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
     basename: messages,ValidationMessages
     encoding: UTF-8
 
+  data:
+    web:
+      pageable:
+        max-page-size: 50
+
 ---
 spring:
   config:

--- a/src/main/resources/static/css/fulfillment.css
+++ b/src/main/resources/static/css/fulfillment.css
@@ -1,11 +1,11 @@
 .table td, .table th {
-    min-width: 56px;
+    min-width: 64px;
     height: 48px;
     vertical-align: middle;
 }
 
 .col-date {
-    min-width: 96px !important;
+    min-width: 112px !important;
 }
 
 .col-expand {

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -6,6 +6,7 @@
     <head>
         <meta charset="UTF-8">
         <title th:replace="${title}">레이아웃 타이틀</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT" crossorigin="anonymous">

--- a/src/main/resources/templates/fragments/pagenation.html
+++ b/src/main/resources/templates/fragments/pagenation.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+
+<!--/*@thymesVar id="nextSortParams" type="java.util.Map<java.lang.String, java.lang.String>"*/-->
+<div th:fragment="sortHeader(paramName, label, nextSortParams)"
+     th:with="nextSortParam = ${nextSortParams.getOrDefault(paramName, 'UNSORTED')}">
+
+    <a th:href="${@replaceOrAddParam.apply('sort', nextSortParam)}">
+
+        <span th:text="${label}">헤더 레이블</span>
+
+        <i class="bi bi-caret-down-fill primary" th:if="${nextSortParam.endsWith('ASC')}"></i>
+        <i class="bi bi-caret-up-fill" th:if="${nextSortParam.equals('UNSORTED')}"></i>
+    </a>
+</div>
+
+</html>

--- a/src/main/resources/templates/fulfillment.html
+++ b/src/main/resources/templates/fulfillment.html
@@ -21,7 +21,9 @@
         </ul>
     </div>
 
-    <div style="height: 16px;"></div>
+    <hr/>
+
+    <div style="height: 8px;"></div>
 
     <div th:replace="~{fragments/sync-result :: syncResult(${synchronizeResponse})}"></div>
 
@@ -236,17 +238,17 @@
 
     <div style="height: 32px;"></div>
 
-    <nav aria-label="Page navigation" th:with="sort=${#strings.listJoin(page.pageable.sort.toString().split(': '), ',')}">
+    <nav aria-label="Page navigation">
         <ul class="pagination justify-content-center">
 
             <li class="page-item" th:classappend="${page.first ? 'disabled' : ''}">
-                <a class="page-link" th:href="@{/v2/fulfillment(page=${page.number - 1}, size=${pageSize}, sort=${sort})}" aria-label="이전 페이지로">
+                <a class="page-link" th:href="${@replaceOrAddParam.apply('page', #strings.toString(page.number - 1))}" aria-label="이전 페이지로">
                     <span aria-hidden="true">&laquo;</span>
                 </a>
             </li>
 
             <li class="page-item" th:classappend="${1 == currentPage ? 'active' : ''}">
-                <a class="page-link" th:href="@{/v2/fulfillment(page=0, size=${pageSize}, sort=${sort})}" th:text="1" th:aria-label="|1번 페이지로|"></a>
+                <a class="page-link"  th:href="${@replaceOrAddParam.apply('page',  #strings.toString(0))}" th:text="1" th:aria-label="|1번 페이지로|"></a>
             </li>
 
             <li class="page-item disabled" th:if="${showLeftDots}">
@@ -256,7 +258,7 @@
             <li class="page-item" th:each="i : ${pageNumbers}"
                 th:if="${i != 1 and i != totalPage}"
                 th:classappend="${i == currentPage ? 'active' : ''}">
-                <a class="page-link" th:href="@{/v2/fulfillment(page=${i - 1}, size=${pageSize}, sort=${sort})}" th:text="${i}" th:aria-label="|${i}번 페이지로|"></a>
+                <a class="page-link" th:href="${@replaceOrAddParam.apply('page', #strings.toString(i - 1))}" th:text="${i}" th:aria-label="|${i}번 페이지로|"></a>
             </li>
 
             <li class="page-item disabled" th:if="${showRightDots}">
@@ -264,11 +266,11 @@
             </li>
 
             <li class="page-item" th:if="${totalPage > 1}" th:classappend="${totalPage == currentPage ? 'active' : ''}">
-                <a class="page-link" th:href="@{/v2/fulfillment(page=${totalPage - 1}, size=${pageSize}, sort=${sort})}" th:text="${totalPage}" th:aria-label="|${totalPage}번 페이지로|"></a>
+                <a class="page-link" th:href="${@replaceOrAddParam.apply('page',  #strings.toString(totalPage - 1))}" th:text="${totalPage}" th:aria-label="|${totalPage}번 페이지로|"></a>
             </li>
 
             <li class="page-item" th:classappend="${page.last ? 'disabled' : ''}">
-                <a class="page-link" th:href="@{/v2/fulfillment(page=${page.number + 1}, size=${pageSize}, sort=${sort})}" aria-label="다음 페이지로">
+                <a class="page-link" th:href="${@replaceOrAddParam.apply('page',  #strings.toString(page.number + 1))}" aria-label="다음 페이지로">
                     <span aria-hidden="true">&raquo;</span>
                 </a>
             </li>

--- a/src/main/resources/templates/fulfillment.html
+++ b/src/main/resources/templates/fulfillment.html
@@ -8,7 +8,7 @@
 
 <body>
 
-<section>
+<section class="p-xl-5 p-md-4 p-sm-3">
 
     <div th:replace="~{modal/sync-smart-store-item-order :: syncSmartStoreItemOrderModal}"></div>
 
@@ -21,166 +21,200 @@
         </ul>
     </div>
 
+    <div style="height: 16px;"></div>
+
     <div th:replace="~{fragments/sync-result :: syncResult(${synchronizeResponse})}"></div>
 
 
-    <form method="POST" th:action="@{/v2/orders/edit}" th:object="${fulfillmentList}">
 
-        <button type="submit">수정</button>
+        <div class="d-flex align-items-end">
+                <div>
+                    총 <span th:text="${page.getTotalElements()}" class="text-primary fw-bold">0</span>건
+                </div>
 
-        <table class="table text-nowrap text-center small align-middle w-100" style="display: block">
+            <div class="flex-grow-1"></div>
 
+            <form method="GET" th:action="@{/v2/fulfillment}">
 
+                <input type="hidden" th:field="${page.pageable.pageNumber}" />
+                <input type="hidden" th:field="${page.pageable.sort}" />
 
-            <thead class="table-light">
-            <tr>
-                <th scope="col">
-                    <input class="form-check-input chk-select-all-rows" type="checkbox" aria-label="전체 선택">
-                </th>
-                <th scope="col">상태</th>
-                <th scope="col">상품주문번호</th>
-                <th class="w-100" scope="col">상품명</th>
-                <th scope="col">합배송</th>
-                <th scope="col">수량</th>
-                <th scope="col">지역</th>
-                <th scope="col">구매자</th>
-                <th scope="col">수취인</th>
-                <th class="col-date" scope="col">주문일자</th>
-                <th scope="col">발송기한</th>
-                <th scope="col">희망배송일자</th>
-                <th class="col-date" scope="col">발주일자</th>
-                <th class="col-date" scope="col">출고일자</th>
-                <th class="col-date" scope="col">배송일자</th>
-                <th scope="col">송장번호</th>
-                <th class="col-date" scope="col">확정일자</th>
-                <th class="col-date" scope="col">취소일자</th>
-                <th class="col-date" scope="col">반품일자</th>
-            </tr>
+                <div class="d-flex align-items-center gap-2">
 
-            <tr>
-                <th scope="col"></th>
-                <th scope="col" colspan="4">고객메모</th>
-                <th scope="col" colspan="6">발주메모</th>
-                <th scope="col" colspan="4">배송메모</th>
-                <th scope="col" colspan="4">관리자메모</th>
-            </tr>
-            </thead>
-
-            <tbody th:each="fulfillment : *{getFulfillmentList}"
-                   th:class="|table-row ${fulfillment.getItemOrderState.name().toLowerCase()}|"
-                    th:classappend="${fulfillmentStat.even ? 'table-light' : ''}"
-            >
-            <tr >
-                <td class="td">
-                    <input type="checkbox"
-                           aria-label="선택"
-                           class="form-check-input chk-select-row">
-                </td>
-
-                <td class="td">
-                    <select class="form-select form-select-sm" aria-label="주문 상태 선택" style="min-width: 72px">
-                        <option th:each="itemOrderState : ${itemOrderStates}"
-                                th:value="${itemOrderState}"
-                                th:text="${itemOrderState.description}"
-                                th:selected="${itemOrderState} == *{fulfillmentList[__${fulfillmentStat.index}__].getItemOrderState}">
-                        </option>
-                    </select>
-                </td>
-
-                <td class="td">
-                    <div class="d-flex">
-                        <th:block th:switch="*{fulfillmentList[__${fulfillmentStat.index}__].salesChannel.description}">
-                            <img class="img-order-location" th:case="스마트스토어" src="/image/smartstore.png" aria-label="스마트스토어"  alt="/image/fallback.jpg"/>
-                            <img class="img-order-location" th:case="매장" src="/image/local.png" aria-label="스마트스토어"  alt="/image/fallback.jpg"/>
-                        </th:block>
-
-                        <div style="width: 6px"></div>
-
-                        <a href="#" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].orderNumber}">상품주문번호</a>
+                    <div class="col-auto">
+                        <select id="selectPageSize" class="form-select" aria-label="페이지 크기 선택" name="size">
+                            <option th:selected="${pageSize} == 5" value="5">5개</option>
+                            <option th:selected="${pageSize} == 10" value="10">10개</option>
+                            <option th:selected="${pageSize} == 25" value="25">25개</option>
+                            <option th:selected="${pageSize} == 50" value="50">50개</option>
+                        </select>
                     </div>
 
-                    <input type="hidden" th:field="*{fulfillmentList[__${fulfillmentStat.index}__].orderNumber}">
-                </td>
+                    <div class="col-auto">
+                        <button type="submit" class="btn btn-secondary">변경</button>
+                    </div>
+                </div>
 
-                <td class="col-expand text-start" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].productName}">
-                    상품명
-                </td>
+            </form>
+        </div>
 
-                <td class="td">
-                    <a href="#"
-                       th:classappend="*{fulfillmentList[__${fulfillmentStat.index}__].itemOrderBundleCount > 1} ? 'accent' : ''"
-                       th:text="*{fulfillmentList[__${fulfillmentStat.index}__].itemOrderBundleCount}">
-                        합배송수
-                    </a>
-                </td>
+        <div style="height: 16px;"></div>
 
-                <td class="td"
-                    th:text="*{fulfillmentList[__${fulfillmentStat.index}__].amount}"
-                    th:classappend="*{fulfillmentList[__${fulfillmentStat.index}__].amount > 1} ? 'accent' : ''">
-                    수량
-                </td>
+        <div class="table-responsive" th:object="${fulfillmentList}">
 
-                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].shippingRegionName}">지역</td>
+            <table class="table text-nowrap text-center small align-middle w-100" style="display: block">
 
-                <td class="td">
-                    <a href="#" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].customerName}">구매자</a>
-                </td>
+                <thead class="table-light">
+                <tr>
+                    <th scope="col">
+                        <input class="form-check-input chk-select-all-rows" type="checkbox" aria-label="전체 선택">
+                    </th>
+                    <th scope="col">상태</th>
+                    <th scope="col">상품주문번호</th>
+                    <th class="w-100" scope="col">상품명</th>
+                    <th scope="col">합배송</th>
+                    <th scope="col">수량</th>
+                    <th scope="col">지역</th>
+                    <th scope="col">구매자</th>
+                    <th scope="col">수취인</th>
+                    <th class="col-date" scope="col">주문일자</th>
+                    <th scope="col">발송기한</th>
+                    <th scope="col">희망배송일자</th>
+                    <th class="col-date" scope="col">발주일자</th>
+                    <th class="col-date" scope="col">출고일자</th>
+                    <th class="col-date" scope="col">배송일자</th>
+                    <th scope="col">송장번호</th>
+                    <th class="col-date" scope="col">확정일자</th>
+                    <th class="col-date" scope="col">취소일자</th>
+                    <th class="col-date" scope="col">반품일자</th>
+                </tr>
 
-                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].recipientName}">수취인</td>
+                <tr>
+                    <th scope="col"></th>
+                    <th scope="col" colspan="4">고객메모</th>
+                    <th scope="col" colspan="6">발주메모</th>
+                    <th scope="col" colspan="4">배송메모</th>
+                    <th scope="col" colspan="4">관리자메모</th>
+                </tr>
+                </thead>
 
-                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].getPlacedOn}">주문일자</td>
+                <tbody th:each="fulfillment : *{fulfillmentList}"
+                       th:class="|table-row ${fulfillment.getItemOrderState.name().toLowerCase()}|"
+                       th:classappend="${fulfillmentStat.even ? 'table-light' : ''}">
 
-                <td class="td">
-                    <input class="form-control form-control-sm" type="date" aria-label="발송기한"
-                           th:field="*{fulfillmentList[__${fulfillmentStat.index}__].dispatchDeadline}">
-                </td>
+                <tr >
+                    <td class="td">
+                        <input type="checkbox"
+                               aria-label="선택"
+                               class="form-check-input chk-select-row">
+                    </td>
 
-                <td class="td">
-                    <input class="form-control form-control-sm" type="date" aria-label="희망배송일자"
-                           th:value="*{fulfillmentList[__${fulfillmentStat.index}__].preferredShipsOn}">
-                </td>
+                    <td class="td">
+                        <select class="form-select form-select-sm" aria-label="주문 상태 선택" style="min-width: 72px">
+                            <option th:each="itemOrderState : ${itemOrderStates}"
+                                    th:value="${itemOrderState}"
+                                    th:text="${itemOrderState.description}"
+                                    th:selected="${itemOrderState} == *{fulfillmentList[__${fulfillmentStat.index}__].getItemOrderState}">
+                            </option>
+                        </select>
+                    </td>
 
-                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].purchasedOn}">발주일자</td>
+                    <td class="td">
+                        <div class="d-flex">
+                            <th:block th:switch="*{fulfillmentList[__${fulfillmentStat.index}__].salesChannel.description}">
+                                <img class="img-order-location" th:case="스마트스토어" src="/image/smartstore.png" aria-label="스마트스토어"  alt="/image/fallback.jpg"/>
+                                <img class="img-order-location" th:case="매장" src="/image/local.png" aria-label="스마트스토어"  alt="/image/fallback.jpg"/>
+                            </th:block>
 
-                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].dispatchedOn}">출고일자</td>
+                            <div style="width: 6px"></div>
 
-                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].shippedOn}">배송일자</td>
+                            <a href="#" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].orderNumber}">상품주문번호</a>
+                        </div>
 
-                <td class="td">
-                    <input class="form-control form-control-sm" type="text" aria-label="송장번호"
-                           style="width: 144px"
-                           th:field="*{fulfillmentList[__${fulfillmentStat.index}__].shippingTrackingNumber}">
-                </td>
+                        <input type="hidden" th:field="*{fulfillmentList[__${fulfillmentStat.index}__].orderNumber}">
+                    </td>
 
-                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].confirmedOn}">확정일자</td>
+                    <td class="col-expand text-start" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].productName}">
+                        상품명
+                    </td>
 
-                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].cancelledOn}">취소일자</td>
+                    <td class="td">
+                        <a href="#"
+                           th:classappend="*{fulfillmentList[__${fulfillmentStat.index}__].itemOrderBundleCount > 1} ? 'accent' : ''"
+                           th:text="*{fulfillmentList[__${fulfillmentStat.index}__].itemOrderBundleCount}">
+                            합배송수
+                        </a>
+                    </td>
 
-                <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].refundedOn}">반품일자</td>
-            </tr>
-            <tr>
-                <td class="td"></td>
+                    <td class="td"
+                        th:text="*{fulfillmentList[__${fulfillmentStat.index}__].amount}"
+                        th:classappend="*{fulfillmentList[__${fulfillmentStat.index}__].amount > 1} ? 'accent' : ''">
+                        수량
+                    </td>
 
-                <td colspan="4" class="td text-left" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].customerMemo}">고객메모</td>
+                    <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].shippingRegionName}">지역</td>
 
-                <td class="td" colspan="6">
-                    <input class="form-control form-control-sm" type="text"
-                           th:field="*{fulfillmentList[__${fulfillmentStat.index}__].purchaseMemo}" aria-label="발주메모">
-                </td>
+                    <td class="td">
+                        <a href="#" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].customerName}">구매자</a>
+                    </td>
 
-                <td class="td" colspan="4">
-                    <input class="form-control form-control-sm" type="text"
-                           th:field="*{fulfillmentList[__${fulfillmentStat.index}__].shippingMemo}" aria-label="배송메모">
-                </td>
+                    <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].recipientName}">수취인</td>
 
-                <td class="td" colspan="4">
-                    <input class="form-control form-control-sm" type="text"
-                           th:field="*{fulfillmentList[__${fulfillmentStat.index}__].adminMemo}" aria-label="관리자메모">
-                </td>
-            </tr>
-            </tbody>
-        </table>
-    </form>
+                    <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].getPlacedOn}">주문일자</td>
+
+                    <td class="td">
+                        <input class="form-control form-control-sm" type="date" aria-label="발송기한"
+                               th:field="*{fulfillmentList[__${fulfillmentStat.index}__].dispatchDeadline}">
+                    </td>
+
+                    <td class="td">
+                        <input class="form-control form-control-sm" type="date" aria-label="희망배송일자"
+                               th:value="*{fulfillmentList[__${fulfillmentStat.index}__].preferredShipsOn}">
+                    </td>
+
+                    <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].purchasedOn}">발주일자</td>
+
+                    <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].dispatchedOn}">출고일자</td>
+
+                    <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].shippedOn}">배송일자</td>
+
+                    <td class="td">
+                        <input class="form-control form-control-sm" type="text" aria-label="송장번호"
+                               style="width: 144px"
+                               th:field="*{fulfillmentList[__${fulfillmentStat.index}__].shippingTrackingNumber}">
+                    </td>
+
+                    <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].confirmedOn}">확정일자</td>
+
+                    <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].cancelledOn}">취소일자</td>
+
+                    <td class="td" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].refundedOn}">반품일자</td>
+                </tr>
+                <tr>
+                    <td class="td"></td>
+
+                    <td colspan="4" class="td text-left" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].customerMemo}">고객메모</td>
+
+                    <td class="td" colspan="6">
+                        <input class="form-control form-control-sm" type="text"
+                               th:field="*{fulfillmentList[__${fulfillmentStat.index}__].purchaseMemo}" aria-label="발주메모">
+                    </td>
+
+                    <td class="td" colspan="4">
+                        <input class="form-control form-control-sm" type="text"
+                               th:field="*{fulfillmentList[__${fulfillmentStat.index}__].shippingMemo}" aria-label="배송메모">
+                    </td>
+
+                    <td class="td" colspan="4">
+                        <input class="form-control form-control-sm" type="text"
+                               th:field="*{fulfillmentList[__${fulfillmentStat.index}__].adminMemo}" aria-label="관리자메모">
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+    <div style="height: 32px;"></div>
 
     <nav aria-label="Page navigation" th:with="sort=${#strings.listJoin(page.pageable.sort.toString().split(': '), ',')}">
         <ul class="pagination justify-content-center">

--- a/src/main/resources/templates/fulfillment.html
+++ b/src/main/resources/templates/fulfillment.html
@@ -62,7 +62,7 @@
 
         <div class="table-responsive" th:object="${fulfillmentList}">
 
-            <table class="table text-nowrap text-center small align-middle w-100" style="display: block">
+            <table class="table text-nowrap text-center small align-middle w-100" style="display: block; margin-bottom: 0 !important;">
 
                 <thead class="table-light">
                 <tr>
@@ -74,19 +74,39 @@
                     <th class="w-100" scope="col">상품명</th>
                     <th scope="col">합배송</th>
                     <th scope="col">수량</th>
-                    <th scope="col">지역</th>
+                    <th scope="col">
+                        <div th:replace="fragments/pagenation :: sortHeader('SHIPPING_REGION_NAME', '지역', ${nextSortParams})"></div>
+                    </th>
                     <th scope="col">구매자</th>
                     <th scope="col">수취인</th>
-                    <th class="col-date" scope="col">주문일자</th>
-                    <th scope="col">발송기한</th>
-                    <th scope="col">희망배송일자</th>
-                    <th class="col-date" scope="col">발주일자</th>
-                    <th class="col-date" scope="col">출고일자</th>
-                    <th class="col-date" scope="col">배송일자</th>
+                    <th class="col-date" scope="col">
+                        <div th:replace="fragments/pagenation :: sortHeader('PLACED_ON', '주문일자', ${nextSortParams})"></div>
+                    </th>
+                    <th scope="col">
+                        <div th:replace="fragments/pagenation :: sortHeader('DISPATCH_DEADLINE', '발송기한', ${nextSortParams})"></div>
+                    </th>
+                    <th scope="col">
+                        <div th:replace="fragments/pagenation :: sortHeader('PREFERRED_SHIPS_ON', '희망배송일자', ${nextSortParams})"></div>
+                    </th>
+                    <th class="col-date" scope="col">
+                        <div th:replace="fragments/pagenation :: sortHeader('PURCHASED_ON', '발주일자', ${nextSortParams})"></div>
+                    </th>
+                    <th class="col-date" scope="col">
+                        <div th:replace="fragments/pagenation :: sortHeader('DISPATCHED_ON', '출고일자', ${nextSortParams})"></div>
+                    </th>
+                    <th class="col-date" scope="col">
+                        <div th:replace="fragments/pagenation :: sortHeader('SHIPPED_ON', '출고일자', ${nextSortParams})"></div>
+                    </th>
                     <th scope="col">송장번호</th>
-                    <th class="col-date" scope="col">확정일자</th>
-                    <th class="col-date" scope="col">취소일자</th>
-                    <th class="col-date" scope="col">반품일자</th>
+                    <th class="col-date" scope="col">
+                        <div th:replace="fragments/pagenation :: sortHeader('CONFIRMED_ON', '확정일자', ${nextSortParams})"></div>
+                    </th>
+                    <th class="col-date" scope="col">
+                        <div th:replace="fragments/pagenation :: sortHeader('CANCELLED_ON', '취소일자', ${nextSortParams})"></div>
+                    </th>
+                    <th class="col-date" scope="col">
+                        <div th:replace="fragments/pagenation :: sortHeader('REFUNDED_ON', '반품일자', ${nextSortParams})"></div>
+                    </th>
                 </tr>
 
                 <tr>

--- a/src/main/resources/templates/fulfillment.html
+++ b/src/main/resources/templates/fulfillment.html
@@ -77,37 +77,37 @@
                     <th scope="col">합배송</th>
                     <th scope="col">수량</th>
                     <th scope="col">
-                        <div th:replace="fragments/pagenation :: sortHeader('SHIPPING_REGION_NAME', '지역', ${nextSortParams})"></div>
+                        <div th:replace="~{fragments/pagenation :: sortHeader('SHIPPING_REGION_NAME', '지역', ${nextSortParams})}"></div>
                     </th>
                     <th scope="col">구매자</th>
                     <th scope="col">수취인</th>
                     <th class="col-date" scope="col">
-                        <div th:replace="fragments/pagenation :: sortHeader('PLACED_ON', '주문일자', ${nextSortParams})"></div>
+                        <div th:replace="~{fragments/pagenation :: sortHeader('PLACED_ON', '주문일자', ${nextSortParams})}"></div>
                     </th>
                     <th scope="col">
-                        <div th:replace="fragments/pagenation :: sortHeader('DISPATCH_DEADLINE', '발송기한', ${nextSortParams})"></div>
+                        <div th:replace="~{fragments/pagenation :: sortHeader('DISPATCH_DEADLINE', '발송기한', ${nextSortParams})}"></div>
                     </th>
                     <th scope="col">
-                        <div th:replace="fragments/pagenation :: sortHeader('PREFERRED_SHIPS_ON', '희망배송일자', ${nextSortParams})"></div>
+                        <div th:replace="~{fragments/pagenation :: sortHeader('PREFERRED_SHIPS_ON', '희망배송일자', ${nextSortParams})}"></div>
                     </th>
                     <th class="col-date" scope="col">
-                        <div th:replace="fragments/pagenation :: sortHeader('PURCHASED_ON', '발주일자', ${nextSortParams})"></div>
+                        <div th:replace="~{fragments/pagenation :: sortHeader('PURCHASED_ON', '발주일자', ${nextSortParams})}"></div>
                     </th>
                     <th class="col-date" scope="col">
-                        <div th:replace="fragments/pagenation :: sortHeader('DISPATCHED_ON', '출고일자', ${nextSortParams})"></div>
+                        <div th:replace="~{fragments/pagenation :: sortHeader('DISPATCHED_ON', '출고일자', ${nextSortParams})}"></div>
                     </th>
                     <th class="col-date" scope="col">
-                        <div th:replace="fragments/pagenation :: sortHeader('SHIPPED_ON', '출고일자', ${nextSortParams})"></div>
+                        <div th:replace="~{fragments/pagenation :: sortHeader('SHIPPED_ON', '배송일자', ${nextSortParams})}"></div>
                     </th>
                     <th scope="col">송장번호</th>
                     <th class="col-date" scope="col">
-                        <div th:replace="fragments/pagenation :: sortHeader('CONFIRMED_ON', '확정일자', ${nextSortParams})"></div>
+                        <div th:replace="~{fragments/pagenation :: sortHeader('CONFIRMED_ON', '확정일자', ${nextSortParams})}"></div>
                     </th>
                     <th class="col-date" scope="col">
-                        <div th:replace="fragments/pagenation :: sortHeader('CANCELLED_ON', '취소일자', ${nextSortParams})"></div>
+                        <div th:replace="~{fragments/pagenation :: sortHeader('CANCELLED_ON', '취소일자', ${nextSortParams})}"></div>
                     </th>
                     <th class="col-date" scope="col">
-                        <div th:replace="fragments/pagenation :: sortHeader('REFUNDED_ON', '반품일자', ${nextSortParams})"></div>
+                        <div th:replace="~{fragments/pagenation :: sortHeader('REFUNDED_ON', '반품일자', ${nextSortParams})}"></div>
                     </th>
                 </tr>
 

--- a/src/main/resources/templates/fulfillment.html
+++ b/src/main/resources/templates/fulfillment.html
@@ -156,7 +156,7 @@
                         <input type="hidden" th:field="*{fulfillmentList[__${fulfillmentStat.index}__].orderNumber}">
                     </td>
 
-                    <td class="col-expand text-start" th:text="*{fulfillmentList[__${fulfillmentStat.index}__].productName}">
+                    <td class="col-expand text-start" th:text="|${fulfillment.productName} [${fulfillment.optionInfo}]|">
                         상품명
                     </td>
 


### PR DESCRIPTION
## 관련 이슈
- close #25 
- close #58 
- close #59 

## 작업 목록
- [x] 동적 페이지네이션 구현
    - 입력 박스를 통해 페이지 개수를 `5, 10, 25, 50`개 선택
    - 페이지 최대 개수를 `50개`로 설정
- [x] 동적 정렬 구현
    - '내림차순, 오름차순, 해제' 순서로 동적 정렬을 구현

## 추가 사항
### 컨트롤러에서 동적 정렬할 값을 계산한 이유
동적 정렬 시 '내림차순, 오름차순, 해제' 순서를 컨트롤러에서 계산했다.

표현 영역을 MVC 패턴으로 구현할 때, 뷰(View)의 책임은 오로지 UI 렌더링에 있다. 현재 상태를 기반으로, 동적 값을 계산하는 것은 컨트롤러(Controller)의 역할이기 때문이다.

같은 이유로, 페이지네이션 컨트롤에 들어갈 값 또한 컨트롤러에서 수행했다.