### PR TITLE
Feature: 우편번호 기반 주소 분류 (시/도, 시/군/구)

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -4,7 +4,7 @@
     <inspection_tool class="HtmlUnknownTag" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="myValues">
         <value>
-          <list size="8">
+          <list size="9">
             <item index="0" class="java.lang.String" itemvalue="nobr" />
             <item index="1" class="java.lang.String" itemvalue="noembed" />
             <item index="2" class="java.lang.String" itemvalue="comment" />
@@ -13,6 +13,7 @@
             <item index="5" class="java.lang.String" itemvalue="script" />
             <item index="6" class="java.lang.String" itemvalue="div" />
             <item index="7" class="java.lang.String" itemvalue="tr" />
+            <item index="8" class="java.lang.String" itemvalue="option" />
           </list>
         </value>
       </option>

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/common/model/QRegion.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/common/model/QRegion.java
@@ -1,0 +1,43 @@
+package kr.tatine.manibogo_oms_v2.common.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QRegion is a Querydsl query type for Region
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QRegion extends EntityPathBase<Region> {
+
+    private static final long serialVersionUID = -1207178751L;
+
+    public static final QRegion region = new QRegion("region");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath sido = createString("sido");
+
+    public final StringPath sigungu = createString("sigungu");
+
+    public final StringPath zipCode = createString("zipCode");
+
+    public QRegion(String variable) {
+        super(Region.class, forVariable(variable));
+    }
+
+    public QRegion(Path<? extends Region> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QRegion(PathMetadata metadata) {
+        super(Region.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/QFulfillmentDto.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/QFulfillmentDto.java
@@ -85,9 +85,11 @@ public class QFulfillmentDto extends EntityPathBase<FulfillmentDto> {
 
     public final EnumPath<kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.ShippingMethod> shippingMethod = createEnum("shippingMethod", kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.ShippingMethod.class);
 
-    public final StringPath shippingRegionName = createString("shippingRegionName");
-
     public final StringPath shippingTrackingNumber = createString("shippingTrackingNumber");
+
+    public final StringPath sido = createString("sido");
+
+    public final StringPath sigungu = createString("sigungu");
 
     public QFulfillmentDto(String variable) {
         super(FulfillmentDto.class, forVariable(variable));

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/QFulfillmentDto.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/QFulfillmentDto.java
@@ -69,6 +69,8 @@ public class QFulfillmentDto extends EntityPathBase<FulfillmentDto> {
 
     public final StringPath recipientPhoneNumber2 = createString("recipientPhoneNumber2");
 
+    public final StringPath recipientZipCode = createString("recipientZipCode");
+
     public final DatePath<java.time.LocalDate> refundedOn = createDate("refundedOn", java.time.LocalDate.class);
 
     public final EnumPath<kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.SalesChannel> salesChannel = createEnum("salesChannel", kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.SalesChannel.class);

--- a/src/main/java/kr/tatine/manibogo_oms_v2/common/model/Region.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/common/model/Region.java
@@ -15,13 +15,10 @@ public class Region {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "우편번호")
     private String zipCode;
 
-    @Column(name = "시도")
     private String sido;
 
-    @Column(name = "시군구")
     private String sigungu;
 
     public Region(String zipCode, String sido, String sgg) {

--- a/src/main/java/kr/tatine/manibogo_oms_v2/common/model/Region.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/common/model/Region.java
@@ -1,0 +1,32 @@
+package kr.tatine.manibogo_oms_v2.common.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Region {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "우편번호")
+    private String zipCode;
+
+    @Column(name = "시도")
+    private String sido;
+
+    @Column(name = "시군구")
+    private String sigungu;
+
+    public Region(String zipCode, String sido, String sgg) {
+        this.zipCode = zipCode;
+        this.sido = sido;
+        this.sigungu = sgg;
+    }
+}

--- a/src/main/java/kr/tatine/manibogo_oms_v2/common/model/Region.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/common/model/Region.java
@@ -10,6 +10,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = @Index(name = "IDX_ZIP_CODE", columnList = "zip_code"))
 public class Region {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kr/tatine/manibogo_oms_v2/common/utils/QueryUtilsConfiguration.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/common/utils/QueryUtilsConfiguration.java
@@ -14,7 +14,7 @@ public class QueryUtilsConfiguration {
         return (paramName, newValue) -> ServletUriComponentsBuilder
                 .fromCurrentRequest()
                 .replaceQueryParam(paramName, newValue)
-                .toUriString();
+                .build().toUriString();
     }
 
 }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/infra/JpqlRegionDao.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/infra/JpqlRegionDao.java
@@ -1,0 +1,27 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.infra;
+
+import jakarta.persistence.EntityManager;
+import kr.tatine.manibogo_oms_v2.fulfillment.query.dao.RegionDao;
+import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.RegionDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class JpqlRegionDao implements RegionDao {
+
+    private final EntityManager em;
+
+    @Override
+    public List<RegionDto> findDistinctAll() {
+
+        final String query = """
+            SELECT DISTINCT new kr.tatine.manibogo_oms_v2.fulfillment.query.dto.RegionDto(r.sido, r.sigungu) FROM Region r
+        """;
+
+        return em.createQuery(query, RegionDto.class).getResultList();
+
+    }
+}

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/infra/QueryDslFulfillmentDao.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/infra/QueryDslFulfillmentDao.java
@@ -78,20 +78,11 @@ public class QueryDslFulfillmentDao implements FulfillmentDao {
 
         if (sido == null || sido.isBlank()) return null;
 
-        List<Predicate> predicates = new ArrayList<>();
-        predicates.add(region.sido.eq(sido));
-
-        if (sigungu != null && !sigungu.isBlank()) {
-            predicates.add(region.sigungu.eq(sigungu));
+        if (sigungu == null || sigungu.isBlank()) {
+            return fulfillmentDto.sido.eq(sido);
         }
 
-        final List<String> zipCodesList = queryFactory
-                .select(region.zipCode)
-                .from(region)
-                .where(predicates.toArray(new Predicate[0]))
-                .fetch();
-
-        return fulfillmentDto.recipientZipCode.in(zipCodesList);
+        return fulfillmentDto.sido.eq(sido).and(fulfillmentDto.sigungu.eq(sigungu));
     }
 
     private BooleanExpression eqDetailSearch(FulfillmentQueryParams queryParams) {
@@ -178,7 +169,6 @@ public class QueryDslFulfillmentDao implements FulfillmentDao {
     private Path<?> getPropertyPath(String property) {
         try {
             return switch (FulfillmentSortParam.valueOf(property)) {
-                case SHIPPING_REGION_NAME -> fulfillmentDto.shippingRegionName;
                 case PLACED_ON -> fulfillmentDto.placedOn;
                 case DISPATCH_DEADLINE -> fulfillmentDto.dispatchDeadline;
                 case PREFERRED_SHIPS_ON -> fulfillmentDto.preferredShipsOn;

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dao/RegionDao.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dao/RegionDao.java
@@ -1,0 +1,11 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.query.dao;
+
+import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.RegionDto;
+
+import java.util.List;
+
+public interface RegionDao {
+
+    List<RegionDto> findDistinctAll();
+
+}

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/FulfillmentDto.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/FulfillmentDto.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 @ToString
 @NoArgsConstructor
 @Subselect("""
+
 SELECT
     io.item_order_number,
     o.order_number,
@@ -32,7 +33,8 @@ SELECT
     option_agg.option_info,
     item_order_cnt.item_order_count AS 'item_order_bundle_count',
     io.amount,
-    '아직' AS 'shipping_region_name',
+    r.sido,
+    r.sigungu,
     o.customer_name,
     o.customer_phone_number,
     o.recipient_name,
@@ -63,6 +65,7 @@ FROM
     item_order AS io
     JOIN orders AS o ON io.order_number = o.order_number
     JOIN product AS p ON io.product_number = p.product_number
+    JOIN region AS r ON o.zip_code = r.zip_code
      -- 상품 옵션 정보 집계 View
     LEFT JOIN (
         SELECT
@@ -131,7 +134,9 @@ public class FulfillmentDto {
 
     private int amount;
 
-    private String shippingRegionName;
+    private String sido;
+
+    private String sigungu;
 
     private String customerName;
 

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/FulfillmentDto.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/FulfillmentDto.java
@@ -40,6 +40,7 @@ SELECT
     o.recipient_phone_number_2 as 'recipient_phone_number2',
     o.address1 as 'recipient_address',
     o.address2 as 'recipient_detail_address',
+    o.zip_code as 'recipient_zip_code',
     ioh_agg.placed_on,
     io.dispatch_deadline,
     io.preferred_ships_on,
@@ -145,6 +146,8 @@ public class FulfillmentDto {
     private String recipientAddress;
 
     private String recipientDetailAddress;
+
+    private String recipientZipCode;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate placedOn;

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/FulfillmentQueryParams.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/FulfillmentQueryParams.java
@@ -32,4 +32,8 @@ public class FulfillmentQueryParams {
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate;
 
+    private String sido;
+
+    private String sigungu;
+
 }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/FulfillmentSortParam.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/FulfillmentSortParam.java
@@ -2,7 +2,6 @@ package kr.tatine.manibogo_oms_v2.fulfillment.query.dto;
 
 public enum FulfillmentSortParam {
 
-    SHIPPING_REGION_NAME,
     PLACED_ON,
     DISPATCH_DEADLINE,
     PREFERRED_SHIPS_ON,

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/PurchaseOrderDto.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/PurchaseOrderDto.java
@@ -133,7 +133,7 @@ public class PurchaseOrderDto {
 
         purchaseOrderDto.setItemOrderBundleCount(fulfillmentDto.getItemOrderBundleCount());
         purchaseOrderDto.setAmount(fulfillmentDto.getAmount());
-        purchaseOrderDto.setShippingRegionName(fulfillmentDto.getShippingRegionName());
+        purchaseOrderDto.setShippingRegionName(fulfillmentDto.getSido());
         purchaseOrderDto.setRecipientFullAddress("%s %s".formatted(fulfillmentDto.getRecipientAddress(), fulfillmentDto.getRecipientDetailAddress()));
         purchaseOrderDto.setDispatchDeadline(fulfillmentDto.getDispatchDeadline());
         purchaseOrderDto.setPreferredShipsOn(fulfillmentDto.getPreferredShipsOn());

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/RegionDto.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/query/dto/RegionDto.java
@@ -1,0 +1,22 @@
+package kr.tatine.manibogo_oms_v2.fulfillment.query.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class RegionDto {
+
+    private String sido;
+
+    private String sigungu;
+
+    public RegionDto(String sido, String sigungu) {
+        this.sido = sido;
+        this.sigungu = sigungu;
+    }
+}

--- a/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/ui/FulfillmentController.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/fulfillment/ui/FulfillmentController.java
@@ -5,6 +5,7 @@ import kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.ItemO
 import kr.tatine.manibogo_oms_v2.fulfillment.command.domain.order.model.vo.SalesChannel;
 import kr.tatine.manibogo_oms_v2.fulfillment.query.dao.FulfillmentDao;
 import kr.tatine.manibogo_oms_v2.fulfillment.query.dao.ProductDao;
+import kr.tatine.manibogo_oms_v2.fulfillment.query.dao.RegionDao;
 import kr.tatine.manibogo_oms_v2.fulfillment.query.dto.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Controller
@@ -30,6 +32,8 @@ public class FulfillmentController {
     private final FulfillmentDao fulfillmentDao;
 
     private final ProductDao productDao;
+
+    private final RegionDao regionDao;
 
     @ModelAttribute("itemOrderStates")
     public ItemOrderState[] orderStates() {
@@ -54,6 +58,12 @@ public class FulfillmentController {
     @ModelAttribute("products")
     public List<ProductDto> products() {
         return productDao.findAll();
+    }
+
+    @ModelAttribute("regions")
+    public Map<String, List<String>> regions() {
+        return regionDao.findDistinctAll().stream()
+                .collect(Collectors.groupingBy(RegionDto::getSido, Collectors.mapping(RegionDto::getSigungu, Collectors.toList())));
     }
 
     @GetMapping

--- a/src/main/resources/templates/fulfillment.html
+++ b/src/main/resources/templates/fulfillment.html
@@ -256,9 +256,8 @@
                     <th class="w-100" scope="col">상품명</th>
                     <th scope="col">합배송</th>
                     <th scope="col">수량</th>
-                    <th scope="col">
-                        <div th:replace="~{fragments/pagenation :: sortHeader('SHIPPING_REGION_NAME', '지역', ${nextSortParams})}"></div>
-                    </th>
+                    <th scope="col">시/도</th>
+                    <th scope="col">시/군/구</th>
                     <th scope="col">구매자</th>
                     <th scope="col">수취인</th>
                     <th class="col-date" scope="col">
@@ -367,7 +366,9 @@
                         수량
                     </td>
 
-                    <td class="td" th:text="${fulfillment.shippingRegionName}">지역</td>
+                    <td class="td text-nowrap" th:text="${fulfillment.sido}">시/도</td>
+
+                    <td class="td text-nowrap" th:text="${fulfillment.sigungu}">시/군/구</td>
 
                     <td class="td">
                         <a th:href="@{/v2/fulfillment(detailSearchParam='CUSTOMER_NAME', detailSearch=${fulfillment.customerName})}"
@@ -496,7 +497,7 @@
     document.getElementById('sido')
         .addEventListener('change', (e) => {
             const select = document.getElementById('sigungu');
-            select.innerHTML = '<option selected="selected">시/군/구 선택</option>';
+            select.innerHTML = '<option selected="selected" value>시/군/구 선택</option>';
 
            if (!e.target.value) return;
 

--- a/src/main/resources/templates/fulfillment.html
+++ b/src/main/resources/templates/fulfillment.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html th:replace="~{fragments/layout::layoutFragment (~{::title}, ~{::section}, ~{}, ~{})}"
+<html th:replace="~{fragments/layout::layoutFragment (~{::title}, ~{::section}, ~{}, ~{::script})}"
       xmlns:th="http://www.thymeleaf.org" lang="ko">
 <head>
     <meta charset="UTF-8">
@@ -114,19 +114,18 @@
 
                 <div class="row flex-grow-1">
                     <div class="col-6 col-sm-auto">
-                        <select style="min-width: 160px;" class="form-select mb-3 mb-sm-0" id="selectProvince" aria-label="Floating label select example">
+                        <select th:field="*{sido}" style="min-width: 160px;" class="form-select mb-3 mb-sm-0" aria-label="시/도 선택">
                             <option selected="selected" th:value="null">시/도 선택</option>
-                            <option value="1">One</option>
-                            <option value="2">Two</option>
-                            <option value="3">Three</option>
+                            <option th:each="sido : ${regions.keySet().toArray()}" th:value="${sido}" th:text="${sido}"></option>
                         </select>
                     </div>
                     <div class="col-6 col-sm-auto">
-                        <select style="min-width: 160px;" class="form-select mb-3 mb-sm-0" id="selectCity" aria-label="Floating label select example">
+                        <select th:field="*{sigungu}" style="min-width: 160px;" class="form-select mb-3 mb-sm-0" aria-label="시/군/구 선택">
                             <option selected="selected" th:value="null">시/군/구 선택</option>
-                            <option value="1">One</option>
-                            <option value="2">Two</option>
-                            <option value="3">Three</option>
+
+                            <th:block th:if="*{!#strings.isEmpty(sido)}">
+                                <option th:each="sigungu : ${regions.get(queryParams.sido)}" th:value="${sigungu}" th:text="${sigungu}"></option>
+                            </th:block>
                         </select>
                     </div>
                 </div>
@@ -492,5 +491,19 @@
     </nav>
 </section>
 </body>
+
+<script th:inline="javascript">
+    document.getElementById('sido')
+        .addEventListener('change', (e) => {
+            const select = document.getElementById('sigungu');
+            select.innerHTML = '<option selected="selected">시/군/구 선택</option>';
+
+           if (!e.target.value) return;
+
+           for (const sigungu of [[${regions}]][e.target.value]) {
+               select.innerHTML += `\n<option name="sigungu" value="${sigungu}">${sigungu}</option>`
+           }
+        });
+</script>
 
 </html>


### PR DESCRIPTION
## 연관 이슈
- close #26 

## 작업 목록

![image](https://github.com/user-attachments/assets/58c63677-11d2-49ac-aa46-8c567abb98cf)

우편 번호 구조를 활용해 주소를 시/도와 시/군/구 레벨로 분리헀음
- 외부 시스템을 호출하는 것 비교해, **성능(조회 시간, 다운타임)이 뛰어남**
- 직접 주소를 추출하는 것에 비교해, **보다 유연하고 안정성이 뛰어남**

### 기능 개발
- [x] 시/도 및 시/군/구 동적 선택 기능
    - DB에서 (시/도, 시/군/구) 쌍을 중복을 제거해 조회
    - 애플리케이션에서 이를 (시/도, [시/군/구, 시/군/구...])로 집계함
    - 뷰 레이어에서 타임 리프와 자바스크립트로 초기/선택 시 해당하는 시/군/구 목록을 렌더링
- [x] 우편번호 기반 주소 쿼리 기능
    - JOIN 쿼리로 풀필먼트 조회 모델에 시/도 및 시/군/구 정보 추가
    - 이를 기반으로 QueryDsl에 동적 지역 검색 추가함 

### 성능 개선
- [x] 지역정보 테이블 Join 성능 개선: `6s -> 400ms`
    - 지역정보의 `zip_code` 칼럼에 인덱스를 추가해 JOIN 성능 개선

### 버그 해결
```java
@Configuration
public class QueryUtilsConfiguration {

    @Bean
    public BiFunction<String, String, String> replaceOrAddParam() {
        return (paramName, newValue) -> ServletUriComponentsBuilder
                .fromCurrentRequest()
                .replaceQueryParam(paramName, newValue)
                .build().toUriString();
    }

}
```
- [x] 쿼리 파라미터 유틸 함수 인코딩 중복 문제
    - 브라우저가 URL을 인코딩하는데, 쿼리 유틸 함수에서 그 전에 인코딩을 한번 더 수행
    - `build()` 함수를 호출해 인코딩을 수행하지 않도록 변경함