### PR TITLE
Feature: 회원 목록 조회, 회원 정보 수정, 주문 로그에 사용자 정보 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
 
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/member/command/domain/QMember.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/member/command/domain/QMember.java
@@ -23,7 +23,7 @@ public class QMember extends EntityPathBase<Member> {
 
     public final StringPath password = createString("password");
 
-    public final StringPath role = createString("role");
+    public final EnumPath<Role> role = createEnum("role", Role.class);
 
     public final StringPath username = createString("username");
 

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/member/query/QMemberDto.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/member/query/QMemberDto.java
@@ -1,4 +1,4 @@
-package kr.tatine.manibogo_oms_v2.member.command.domain;
+package kr.tatine.manibogo_oms_v2.member.query;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
@@ -10,14 +10,14 @@ import com.querydsl.core.types.Path;
 
 
 /**
- * QMember is a Querydsl query type for Member
+ * QMemberDto is a Querydsl query type for MemberDto
  */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
-public class QMember extends EntityPathBase<Member> {
+public class QMemberDto extends EntityPathBase<MemberDto> {
 
-    private static final long serialVersionUID = -274563672L;
+    private static final long serialVersionUID = 347050054L;
 
-    public static final QMember member = new QMember("member1");
+    public static final QMemberDto memberDto = new QMemberDto("memberDto");
 
     public final BooleanPath isEnabled = createBoolean("isEnabled");
 
@@ -27,16 +27,16 @@ public class QMember extends EntityPathBase<Member> {
 
     public final StringPath username = createString("username");
 
-    public QMember(String variable) {
-        super(Member.class, forVariable(variable));
+    public QMemberDto(String variable) {
+        super(MemberDto.class, forVariable(variable));
     }
 
-    public QMember(Path<? extends Member> path) {
+    public QMemberDto(Path<? extends MemberDto> path) {
         super(path.getType(), path.getMetadata());
     }
 
-    public QMember(PathMetadata metadata) {
-        super(Member.class, metadata);
+    public QMemberDto(PathMetadata metadata) {
+        super(MemberDto.class, metadata);
     }
 
 }

--- a/src/main/generated/kr/tatine/manibogo_oms_v2/order/command/domain/model/QOrderLog.java
+++ b/src/main/generated/kr/tatine/manibogo_oms_v2/order/command/domain/model/QOrderLog.java
@@ -24,6 +24,8 @@ public class QOrderLog extends EntityPathBase<OrderLog> {
 
     public final DateTimePath<java.time.LocalDateTime> changedAt = createDateTime("changedAt", java.time.LocalDateTime.class);
 
+    public final StringPath changedBy = createString("changedBy");
+
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
     public final EnumPath<kr.tatine.manibogo_oms_v2.order.command.domain.model.vo.OrderState> newState = createEnum("newState", kr.tatine.manibogo_oms_v2.order.command.domain.model.vo.OrderState.class);

--- a/src/main/java/kr/tatine/manibogo_oms_v2/common/config/MemberUserDetailsService.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/common/config/MemberUserDetailsService.java
@@ -1,30 +1,35 @@
 package kr.tatine.manibogo_oms_v2.common.config;
 
-import kr.tatine.manibogo_oms_v2.member.command.domain.Member;
-import kr.tatine.manibogo_oms_v2.member.command.domain.MemberRepository;
+import kr.tatine.manibogo_oms_v2.member.query.MemberDao;
+import kr.tatine.manibogo_oms_v2.member.query.MemberDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-
-import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-public class MemberUserDetailService implements UserDetailsService {
+public class MemberUserDetailsService implements UserDetailsService {
 
-    private final MemberRepository memberRepository;
+    private final MemberDao memberDao;
 
     @Override
+    @Transactional
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return memberRepository.findById(username)
+        return memberDao.findById(username)
                 .map(this::createUserDetails)
                 .orElseThrow(() -> new UsernameNotFoundException(""));
     }
 
-    private UserDetails createUserDetails(Member member) {
-        return new User(member.getUsername(), member.getPassword(), List.of(new SimpleGrantedAuthority(member.getRole())));
+    private UserDetails createUserDetails(MemberDto memberDto) {
+        return User.builder()
+                .username(memberDto.getUsername())
+                .password(memberDto.getPassword())
+                .authorities(new SimpleGrantedAuthority(memberDto.getRole()))
+                .disabled(!memberDto.getIsEnabled())
+                .build();
     }
 
 }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/common/config/SecurityConfig.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/common/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package kr.tatine.manibogo_oms_v2.common.config;
 
-import kr.tatine.manibogo_oms_v2.member.command.domain.MemberRepository;
+import kr.tatine.manibogo_oms_v2.member.query.MemberDao;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,7 +27,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, RememberMeServices rememberMeServices) throws Exception {
         http.authorizeHttpRequests(request -> request
-                .requestMatchers("/v2/orders", "/v2/orders/**", "/v2/products", "/v2/products/**", "/v2/synchronize/**").hasRole("ADMIN")
+                .requestMatchers("/v2/orders", "/v2/orders/**", "/v2/products", "/v2/products/**", "/v2/synchronize/**", "/v2/members", "/v2/members/**").hasRole("ADMIN")
                 .requestMatchers("/v2/logistics", "/v2/logistics/**").hasAnyRole("ADMIN", "LOGISTICS")
                 .requestMatchers("/error", "/image/**", "/js/**", "/css/**").permitAll())
                 .formLogin(Customizer.withDefaults())
@@ -47,8 +47,8 @@ public class SecurityConfig {
     }
 
     @Bean
-    public UserDetailsService userDetailsService(MemberRepository memberRepository) {
-        return new MemberUserDetailService(memberRepository);
+    public UserDetailsService userDetailsService(MemberDao memberDao) {
+        return new MemberUserDetailsService(memberDao);
     }
 
     @Bean

--- a/src/main/java/kr/tatine/manibogo_oms_v2/common/model/CommonResponse.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/common/model/CommonResponse.java
@@ -1,14 +1,14 @@
 package kr.tatine.manibogo_oms_v2.common.model;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+
+import java.io.Serializable;
 
 @Getter
 @Setter
+@ToString
 @NoArgsConstructor
-public class CommonResponse {
+public class CommonResponse implements Serializable {
 
     private Message message;
 

--- a/src/main/java/kr/tatine/manibogo_oms_v2/common/model/ErrorResult.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/common/model/ErrorResult.java
@@ -2,10 +2,11 @@ package kr.tatine.manibogo_oms_v2.common.model;
 
 import lombok.Getter;
 
+import java.io.Serializable;
 import java.util.*;
 
 @Getter
-public class ErrorResult {
+public class ErrorResult implements Serializable {
 
     private final Map<String, FieldError> fieldErrors = new HashMap<>();
 

--- a/src/main/java/kr/tatine/manibogo_oms_v2/common/model/FieldError.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/common/model/FieldError.java
@@ -1,10 +1,11 @@
 package kr.tatine.manibogo_oms_v2.common.model;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 public record FieldError(
-        ErrorLevel level, List<Message> messages) {
+        ErrorLevel level, List<Message> messages) implements Serializable {
 
     public FieldError addError(ErrorLevel level, Message message) {
         ArrayList<Message> prevMessages = new ArrayList<>(messages);

--- a/src/main/java/kr/tatine/manibogo_oms_v2/common/model/GlobalError.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/common/model/GlobalError.java
@@ -1,6 +1,8 @@
 package kr.tatine.manibogo_oms_v2.common.model;
 
 
-public record GlobalError(ErrorLevel level, Message message) {
+import java.io.Serializable;
+
+public record GlobalError(ErrorLevel level, Message message) implements Serializable {
 
 }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/common/model/Message.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/common/model/Message.java
@@ -1,3 +1,5 @@
 package kr.tatine.manibogo_oms_v2.common.model;
 
-public record Message(String messageCode, Object[] arguments) { }
+import java.io.Serializable;
+
+public record Message(String messageCode, Object[] arguments) implements Serializable { }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/member/command/application/EditMemberCommand.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/member/command/application/EditMemberCommand.java
@@ -1,0 +1,7 @@
+package kr.tatine.manibogo_oms_v2.member.command.application;
+
+public record EditMemberCommand(
+        String username,
+        String password,
+        String repeatPassword
+) { }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/member/command/application/EditMemberService.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/member/command/application/EditMemberService.java
@@ -1,0 +1,54 @@
+package kr.tatine.manibogo_oms_v2.member.command.application;
+
+import kr.tatine.manibogo_oms_v2.ValidationErrorException;
+import kr.tatine.manibogo_oms_v2.common.ValidationError;
+import kr.tatine.manibogo_oms_v2.member.command.domain.Member;
+import kr.tatine.manibogo_oms_v2.member.command.domain.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class EditMemberService {
+
+    private final MemberRepository memberRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void edit(EditMemberCommand command) {
+
+        final List<ValidationError> errors = new ArrayList<>();
+
+        if (Strings.isBlank(command.username())) {
+            errors.add(ValidationError.of("username", "required.username"));
+        }
+        if (Strings.isNotBlank(command.password())) {
+
+            if (!Objects.equals(command.password(), command.repeatPassword())) {
+                errors.add(ValidationError.of("repeatPassword", "notMatched.repeatPassword"));
+            }
+            if (command.password().length() > 4) {
+                errors.add(ValidationError.of("password", "length.password"));
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            throw new ValidationErrorException(errors);
+        }
+
+        final Member member = memberRepository.findById(command.username())
+                .orElseThrow(MemberNotFoundException::new);
+
+        member.changePassword(passwordEncoder.encode(command.password()));
+    }
+
+}

--- a/src/main/java/kr/tatine/manibogo_oms_v2/member/command/application/MemberNotFoundException.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/member/command/application/MemberNotFoundException.java
@@ -1,0 +1,3 @@
+package kr.tatine.manibogo_oms_v2.member.command.application;
+
+public class MemberNotFoundException extends RuntimeException { }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/member/command/domain/Member.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/member/command/domain/Member.java
@@ -29,4 +29,12 @@ public class Member {
         this.role = role;
         this.isEnabled = isEnabled;
     }
+
+    public void changePassword(String newPassword) {
+        this.password = newPassword;
+    }
+
+    public void changeIsEnabled(Boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
 }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/member/command/domain/Member.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/member/command/domain/Member.java
@@ -1,9 +1,10 @@
 package kr.tatine.manibogo_oms_v2.member.command.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
@@ -17,11 +18,12 @@ public class Member {
 
     private String password;
 
-    private String role;
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
     private Boolean isEnabled;
 
-    public Member(String username, String password, String role, Boolean isEnabled) {
+    public Member(String username, String password, Role role, Boolean isEnabled) {
         this.username = username;
         this.password = password;
         this.role = role;

--- a/src/main/java/kr/tatine/manibogo_oms_v2/member/command/domain/Role.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/member/command/domain/Role.java
@@ -1,0 +1,7 @@
+package kr.tatine.manibogo_oms_v2.member.command.domain;
+
+public enum Role {
+
+    ROLE_ADMIN, ROLE_LOGISTICS;
+
+}

--- a/src/main/java/kr/tatine/manibogo_oms_v2/member/query/MemberDao.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/member/query/MemberDao.java
@@ -1,0 +1,11 @@
+package kr.tatine.manibogo_oms_v2.member.query;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberDao extends JpaRepository<MemberDto, String> {
+
+    Page<MemberDto> findAll(Pageable pageable);
+
+}

--- a/src/main/java/kr/tatine/manibogo_oms_v2/member/query/MemberDto.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/member/query/MemberDto.java
@@ -1,16 +1,19 @@
-package kr.tatine.manibogo_oms_v2.member.command.domain;
+package kr.tatine.manibogo_oms_v2.member.query;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
+@Getter
 @ToString
+@Table(name = "member")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class MemberDto {
 
     @Id
     private String username;
@@ -21,10 +24,5 @@ public class Member {
 
     private Boolean isEnabled;
 
-    public Member(String username, String password, String role, Boolean isEnabled) {
-        this.username = username;
-        this.password = password;
-        this.role = role;
-        this.isEnabled = isEnabled;
-    }
 }
+

--- a/src/main/java/kr/tatine/manibogo_oms_v2/member/ui/MemberController.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/member/ui/MemberController.java
@@ -1,0 +1,44 @@
+package kr.tatine.manibogo_oms_v2.member.ui;
+
+import kr.tatine.manibogo_oms_v2.member.command.domain.Role;
+import kr.tatine.manibogo_oms_v2.member.query.MemberDao;
+import kr.tatine.manibogo_oms_v2.member.query.MemberDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/v2/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberDao memberDao;
+
+    @ModelAttribute("roles")
+    public Role[] roles() {
+        return Role.values();
+    }
+
+    @GetMapping
+    @Transactional(readOnly = true)
+    public String members(Model model, @PageableDefault Pageable pageable) {
+
+        final Page<MemberDto> page = memberDao.findAll(pageable);
+
+        final MemberRowsForm rowsForm = new MemberRowsForm();
+        rowsForm.setRows(page.getContent().stream().map(MemberRowsForm.Row::of).toList());
+
+        model.addAttribute("rowsForm", rowsForm);
+        model.addAttribute("page", page);
+
+        return "members";
+    }
+
+}

--- a/src/main/java/kr/tatine/manibogo_oms_v2/member/ui/MemberController.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/member/ui/MemberController.java
@@ -1,8 +1,15 @@
 package kr.tatine.manibogo_oms_v2.member.ui;
 
+import kr.tatine.manibogo_oms_v2.ValidationErrorException;
+import kr.tatine.manibogo_oms_v2.common.model.CommonResponse;
+import kr.tatine.manibogo_oms_v2.common.model.ErrorResult;
+import kr.tatine.manibogo_oms_v2.common.utils.SelectableRowsFormUtils;
+import kr.tatine.manibogo_oms_v2.member.command.application.EditMemberService;
+import kr.tatine.manibogo_oms_v2.member.command.application.MemberNotFoundException;
 import kr.tatine.manibogo_oms_v2.member.command.domain.Role;
 import kr.tatine.manibogo_oms_v2.member.query.MemberDao;
 import kr.tatine.manibogo_oms_v2.member.query.MemberDto;
+import kr.tatine.manibogo_oms_v2.variant.command.application.VariantNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,12 +19,18 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import static kr.tatine.manibogo_oms_v2.common.utils.SelectableRowsFormUtils.getRowsFieldName;
 
 @Controller
 @RequestMapping("/v2/members")
 @RequiredArgsConstructor
 public class MemberController {
+
+    private final EditMemberService editMemberService;
 
     private final MemberDao memberDao;
 
@@ -39,6 +52,31 @@ public class MemberController {
         model.addAttribute("page", page);
 
         return "members";
+    }
+
+    @PostMapping("/edit")
+    public String editMembers(@ModelAttribute("rowsForm") MemberRowsForm rowsForm, RedirectAttributes redirectAttributes) {
+
+        final ErrorResult errorResult = new ErrorResult();
+
+        SelectableRowsFormUtils.handle(rowsForm, errorResult, (i, row) -> {
+            try {
+                editMemberService.edit(row.toCommand());
+
+            } catch (ValidationErrorException ex) {
+                ex.getValidationErrors().forEach(error ->
+                        errorResult.rejectValue(getRowsFieldName(i, error.getName()), error.getErrorCode()));
+
+            } catch (MemberNotFoundException ex) {
+                errorResult.reject("notFound.member");
+            }
+        });
+
+
+        redirectAttributes.addFlashAttribute("response",
+                new CommonResponse("complete.editMembers", errorResult));
+
+        return "redirect:/v2/members";
     }
 
 }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/member/ui/MemberRowsForm.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/member/ui/MemberRowsForm.java
@@ -1,0 +1,52 @@
+package kr.tatine.manibogo_oms_v2.member.ui;
+
+import kr.tatine.manibogo_oms_v2.common.model.SelectableRow;
+import kr.tatine.manibogo_oms_v2.common.model.SelectableRowsForm;
+import kr.tatine.manibogo_oms_v2.member.query.MemberDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class MemberRowsForm implements SelectableRowsForm<MemberRowsForm.Row> {
+
+    private List<Row> rows = new ArrayList<>();
+
+    @Getter
+    @Setter
+    @ToString
+    @NoArgsConstructor
+    public static class Row implements SelectableRow {
+
+        private Boolean isSelected = false;
+
+        private String username;
+
+        private String role;
+
+        private String newPassword;
+
+        private String repeatNewPassword;
+
+        private Boolean isEnabled;
+
+        public static MemberRowsForm.Row of(MemberDto memberDto) {
+            final Row row = new Row();
+
+            row.setUsername(memberDto.getUsername());
+            row.setRole(memberDto.getRole());
+            row.setIsEnabled(memberDto.getIsEnabled());
+
+            return row;
+        }
+
+    }
+
+}

--- a/src/main/java/kr/tatine/manibogo_oms_v2/member/ui/MemberRowsForm.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/member/ui/MemberRowsForm.java
@@ -2,6 +2,7 @@ package kr.tatine.manibogo_oms_v2.member.ui;
 
 import kr.tatine.manibogo_oms_v2.common.model.SelectableRow;
 import kr.tatine.manibogo_oms_v2.common.model.SelectableRowsForm;
+import kr.tatine.manibogo_oms_v2.member.command.application.EditMemberCommand;
 import kr.tatine.manibogo_oms_v2.member.query.MemberDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,20 +32,20 @@ public class MemberRowsForm implements SelectableRowsForm<MemberRowsForm.Row> {
 
         private String role;
 
-        private String newPassword;
+        private String password;
 
-        private String repeatNewPassword;
-
-        private Boolean isEnabled;
+        private String repeatPassword;
 
         public static MemberRowsForm.Row of(MemberDto memberDto) {
             final Row row = new Row();
-
             row.setUsername(memberDto.getUsername());
             row.setRole(memberDto.getRole());
-            row.setIsEnabled(memberDto.getIsEnabled());
 
             return row;
+        }
+
+        public EditMemberCommand toCommand() {
+            return new EditMemberCommand(getUsername(), getPassword(), getRepeatPassword());
         }
 
     }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/order/command/application/dto/CreateOrderLogCommand.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/order/command/application/dto/CreateOrderLogCommand.java
@@ -6,5 +6,6 @@ public record CreateOrderLogCommand(
         String orderNumber,
         String previousState,
         String newState,
-        LocalDateTime changedAt
+        LocalDateTime changedAt,
+        String changedBy
 ) { }

--- a/src/main/java/kr/tatine/manibogo_oms_v2/order/command/application/service/CreateOrderLogService.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/order/command/application/service/CreateOrderLogService.java
@@ -17,21 +17,21 @@ public class CreateOrderLogService {
 
     private final OrderLogRepository repository;
 
-    @Transactional
     public void create(CreateOrderLogCommand command) {
 
         final OrderState previousState = getPreviousStateOrNull(command);
 
         final OrderState newState = OrderState.valueOf(command.newState());
 
-        final OrderLog history = new OrderLog(
+        final OrderLog orderLog = new OrderLog(
                 new OrderNumber(command.orderNumber()),
                 previousState,
                 newState,
-                command.changedAt()
+                command.changedAt(),
+                command.changedBy()
         );
 
-        repository.save(history);
+        repository.save(orderLog);
     }
 
     private OrderState getPreviousStateOrNull(CreateOrderLogCommand command) {

--- a/src/main/java/kr/tatine/manibogo_oms_v2/order/command/domain/model/OrderLog.java
+++ b/src/main/java/kr/tatine/manibogo_oms_v2/order/command/domain/model/OrderLog.java
@@ -27,16 +27,21 @@ public class OrderLog {
 
     private LocalDateTime changedAt;
 
+    private String changedBy;
+
     public OrderLog(
             OrderNumber orderNumber,
             OrderState previousState,
             OrderState newState,
-            LocalDateTime changedAt) {
+            LocalDateTime changedAt,
+            String changedBy
+    ) {
 
         this.orderNumber = orderNumber;
         this.previousState = previousState;
         this.newState = newState;
         this.changedAt = changedAt;
+        this.changedBy = changedBy;
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   profiles:
     active: local
 
+  session:
+    redis:
+      namespace: manibogo
+
   messages:
     basename: messages,ValidationMessages
     encoding: UTF-8

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -60,6 +60,7 @@ stateAlreadyProceed=이미 {0} 이후 상태입니다.
 
 #==ObjectMessage==
 #Level1
+complete.editMembers=선택한 회원 정보를 수정했습니다.
 complete.editSummaries=상품 주문 수정을 완료헀습니다.
 complete.proceedState=선택 주문을 {0} 상태로 진전했습니다. 이미 {0} 상태이거나 이후인 건은 무시됩니다.
 complete.editProducts=선택한 상품의 정보를 수정했습니다.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -66,6 +66,8 @@ complete.editProducts=선택한 상품의 정보를 수정했습니다.
 complete.editVariants=선택한 상품 옵션의 정보를 수정했습니다.
 
 #Level2
+ROLE_ADMIN=관리자
+ROLE_LOGISTICS=배송팀
 
 #==FieldMessage==
 #Level1

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -33,7 +33,9 @@
                     </a>
                 </li>
                 <li class="nav-item"  sec:authorize="hasRole('ADMIN')">
-                    <a class="nav-link" href="#">
+                    <a class="nav-link"
+                       href="/v2/members"
+                       th:classappend="${path.startsWith('/v2/members') ? 'active' : ''}">
                         회원관리
                     </a>
                 </li>

--- a/src/main/resources/templates/members.html
+++ b/src/main/resources/templates/members.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html th:replace="~{fragments/layout::layoutFragment (~{::title}, ~{::section}, ~{}, ~{})}"
+      xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>마니보고 주문관리 서비스 V2 - 회원관리</title>
+</head>
+<body>
+
+<section class="p-4">
+    <form th:object="${rowsForm}" th:method="POST" th:action="${@replaceUri.apply('/v2/members/edit')}">
+
+        <nav class="d-flex">
+            <div class="flex-grow-1"></div>
+
+            <button type="submit" class="btn btn-primary">
+                <i class="bi bi-pencil-fill"></i> 선택수정
+            </button>
+        </nav>
+
+        <hr/>
+
+        <div style="height: 24px;"></div>
+
+
+        <div class="container-xxl">
+
+            <div th:if="${response?.errorResult?.hasGlobalError()}">
+                <div role="alert" class="alert alert-danger"
+                     th:with="errorLevel = ${err.level().name().toLowerCase()}"
+                     th:each="err : ${response?.errorResult?.getGlobalErrors()}"
+                     th:text="${#messages.msgWithParams(err.message().messageCode(), err.message().arguments())}">
+                    에러 메세지
+                </div>
+            </div>
+            <div th:if="${response?.message != null}" class="alert alert-primary" role="alert" th:text="${#messages.msgWithParams(response.message.messageCode(), response.message.arguments())}">메세지</div>
+
+            <div th:replace="~{fragments/pagenation :: pageHeader('/v2/members', ${page}, ~{})}"></div>
+
+            <div style="height: 16px;"></div>
+
+            <div class="table-responsive">
+                <table class="table table-striped text-center small align-middle w-100 text-nowrap" style="margin-bottom: 0 !important;">
+                    <thead class="table-light">
+                    <tr>
+                        <th scope="col">
+                            <input class="form-check-input chk-select-all-rows" type="checkbox" aria-label="전체 선택">
+                        </th>
+                        <th scope="col" style="min-width: 128px;">아이디</th>
+                        <th scope="col" style="min-width: 128px;">역할</th>
+                        <th scope="col" style="width: 50%">비밀번호</th>
+                        <th scope="col" style="width: 50%">비밀번호 확인</th>
+                        <th scope="col" style="min-width: 88px;">사용</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="table-row" th:each="_, rowStat : *{rows}">
+                        <td class="td">
+                            <input type="checkbox"
+                                   aria-label="선택"
+                                   class="form-check-input chk-select-row"
+                                   th:field="*{rows[__${rowStat.index}__].isSelected}" />
+                        </td>
+                        <td>
+                            <span th:text="*{rows[__${rowStat.index}__].username}"></span>
+                            <input type="hidden" th:field="*{rows[__${rowStat.index}__].username}">
+                        </td>
+                        <td class="position-relative">
+                            <span th:text="#{*{rows[__${rowStat.index}__].role}}"></span>
+                            <input type="hidden" th:field="*{rows[__${rowStat.index}__].role}">
+                        </td>
+                        <td th:with="fieldName = |rows[${rowStat.index}].newPassword|, fieldError = ${response?.errorResult?.getFieldError(fieldName)}">
+                            <input type="password"
+                                   class="form-control form-control-sm"
+                                   th:classappend="${fieldError != null ? 'is-invalid' : ''}"
+                                   th:field="*{rows[__${rowStat.index}__].newPassword}" />
+
+                            <div class="invalid-feedback"
+                                 th:each="message : ${fieldError?.messages()}"
+                                 th:text="${#messages.msgWithParams(message.messageCode(), message.arguments())}">
+                                에러 메세지
+                            </div>
+                        </td>
+                        <td th:with="fieldName = |rows[${rowStat.index}].repeatNewPassword|, fieldError = ${response?.errorResult?.getFieldError(fieldName)}">
+                            <input type="password"
+                                   class="form-control form-control-sm"
+                                   th:classappend="${fieldError != null ? 'is-invalid' : ''}"
+                                   th:field="*{rows[__${rowStat.index}__].repeatNewPassword}" />
+
+                            <div class="invalid-feedback"
+                                 th:each="message : ${fieldError?.messages()}"
+                                 th:text="${#messages.msgWithParams(message.messageCode(), message.arguments())}">
+                                에러 메세지
+                            </div>
+                        </td>
+                        <td>
+                            <input type="checkbox"
+                                   aria-label="사용"
+                                   class="form-check-input"
+                                   th:field="*{rows[__${rowStat.index}__].isEnabled}" />
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </form>
+
+    <div style="height: 32px;"></div>
+
+    <div th:replace="~{fragments/pagenation :: pageControl(${page})}"></div>
+
+</section>
+</body>
+</html>

--- a/src/main/resources/templates/members.html
+++ b/src/main/resources/templates/members.html
@@ -27,7 +27,6 @@
 
             <div th:if="${response?.errorResult?.hasGlobalError()}">
                 <div role="alert" class="alert alert-danger"
-                     th:with="errorLevel = ${err.level().name().toLowerCase()}"
                      th:each="err : ${response?.errorResult?.getGlobalErrors()}"
                      th:text="${#messages.msgWithParams(err.message().messageCode(), err.message().arguments())}">
                     에러 메세지
@@ -50,7 +49,6 @@
                         <th scope="col" style="min-width: 128px;">역할</th>
                         <th scope="col" style="width: 50%">비밀번호</th>
                         <th scope="col" style="width: 50%">비밀번호 확인</th>
-                        <th scope="col" style="min-width: 88px;">사용</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -69,11 +67,11 @@
                             <span th:text="#{*{rows[__${rowStat.index}__].role}}"></span>
                             <input type="hidden" th:field="*{rows[__${rowStat.index}__].role}">
                         </td>
-                        <td th:with="fieldName = |rows[${rowStat.index}].newPassword|, fieldError = ${response?.errorResult?.getFieldError(fieldName)}">
+                        <td th:with="fieldName = |rows[${rowStat.index}].password|, fieldError = ${response?.errorResult?.getFieldError(fieldName)}">
                             <input type="password"
                                    class="form-control form-control-sm"
                                    th:classappend="${fieldError != null ? 'is-invalid' : ''}"
-                                   th:field="*{rows[__${rowStat.index}__].newPassword}" />
+                                   th:field="*{rows[__${rowStat.index}__].password}" />
 
                             <div class="invalid-feedback"
                                  th:each="message : ${fieldError?.messages()}"
@@ -81,23 +79,17 @@
                                 에러 메세지
                             </div>
                         </td>
-                        <td th:with="fieldName = |rows[${rowStat.index}].repeatNewPassword|, fieldError = ${response?.errorResult?.getFieldError(fieldName)}">
+                        <td th:with="fieldName = |rows[${rowStat.index}].repeatPassword|, fieldError = ${response?.errorResult?.getFieldError(fieldName)}">
                             <input type="password"
                                    class="form-control form-control-sm"
                                    th:classappend="${fieldError != null ? 'is-invalid' : ''}"
-                                   th:field="*{rows[__${rowStat.index}__].repeatNewPassword}" />
+                                   th:field="*{rows[__${rowStat.index}__].repeatPassword}" />
 
                             <div class="invalid-feedback"
                                  th:each="message : ${fieldError?.messages()}"
                                  th:text="${#messages.msgWithParams(message.messageCode(), message.arguments())}">
                                 에러 메세지
                             </div>
-                        </td>
-                        <td>
-                            <input type="checkbox"
-                                   aria-label="사용"
-                                   class="form-check-input"
-                                   th:field="*{rows[__${rowStat.index}__].isEnabled}" />
                         </td>
                     </tr>
                     </tbody>


### PR DESCRIPTION
## 연관 이슈
- close #23 
- close #22 

## 작업 목록
- [x] Redis 스토리지로 세션 정보 영속화
    - 세션에 담기는 DTO를 모두 `Serializable`을 구현하였음
- [x] 회원 목록 조회/수정 기능
- [x] 주문 로그에 사용자 정보 추가
   - 전파 레벨을 지정해 로그 생성을 별도 트랜잭션으로 분리